### PR TITLE
Fixes #8 for 1.19.x only

### DIFF
--- a/1_13_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R1.java
+++ b/1_13_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R1.java
@@ -1398,7 +1398,7 @@ public final class ChipUtil1_13_R1 implements ChipUtil {
                     Field f = clazz.getDeclaredField(name);
                     f.setAccessible(true);
                     return cast.cast(f.get(o));
-                } catch (NoSuchFieldException e) {
+                } catch (NoSuchFieldException | ClassCastException e) {
                     if (PathfinderGoal.class.isAssignableFrom(clazz.getSuperclass())) clazz = (Class<? extends PathfinderGoal>) clazz.getSuperclass();
                     else break;
                 }
@@ -1417,7 +1417,10 @@ public final class ChipUtil1_13_R1 implements ChipUtil {
 
     private static BlockPosition toNMS(Location l) { return new BlockPosition(l.getX(), l.getY(), l.getZ()); }
 
-    private static List<ItemStack> fromNMS(RecipeItemStack in) { return Arrays.stream(in.choices).map(CraftItemStack::asBukkitCopy).collect(Collectors.toList()); }
+    private static List<ItemStack> fromNMS(RecipeItemStack in) {
+        in.buildChoices();
+        return Arrays.stream(in.choices).map(CraftItemStack::asBukkitCopy).collect(Collectors.toList());
+    }
 
     private static Sound fromNMS(SoundEffect s) {
         try {

--- a/1_13_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R2.java
+++ b/1_13_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R2.java
@@ -1384,7 +1384,7 @@ public class ChipUtil1_13_R2 implements ChipUtil {
                     Field f = clazz.getDeclaredField(name);
                     f.setAccessible(true);
                     return cast.cast(f.get(o));
-                } catch (NoSuchFieldException e) {
+                } catch (NoSuchFieldException | ClassCastException e) {
                     if (PathfinderGoal.class.isAssignableFrom(clazz.getSuperclass())) clazz = (Class<? extends PathfinderGoal>) clazz.getSuperclass();
                     else break;
                 }
@@ -1405,7 +1405,10 @@ public class ChipUtil1_13_R2 implements ChipUtil {
 
     private static BlockPosition toNMS(Location l) { return new BlockPosition(l.getX(), l.getY(), l.getZ()); }
 
-    private static List<ItemStack> fromNMS(RecipeItemStack in) { return Arrays.stream(in.choices).map(CraftItemStack::asBukkitCopy).collect(Collectors.toList()); }
+    private static List<ItemStack> fromNMS(RecipeItemStack in) {
+        in.buildChoices();
+        return Arrays.stream(in.choices).map(CraftItemStack::asBukkitCopy).collect(Collectors.toList());
+    }
 
     private static Sound fromNMS(SoundEffect s) {
         try {

--- a/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_14_R1.java
+++ b/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_14_R1.java
@@ -1695,7 +1695,7 @@ public class ChipUtil1_14_R1 implements ChipUtil {
                     Field f = clazz.getDeclaredField(name);
                     f.setAccessible(true);
                     return cast.cast(f.get(o));
-                } catch (NoSuchFieldException e) {
+                } catch (NoSuchFieldException | ClassCastException e) {
                     if (PathfinderGoal.class.isAssignableFrom(clazz.getSuperclass())) clazz = (Class<? extends PathfinderGoal>) clazz.getSuperclass();
                     else break;
                 }
@@ -1716,7 +1716,10 @@ public class ChipUtil1_14_R1 implements ChipUtil {
 
     private static BlockPosition toNMS(Location l) { return new BlockPosition(l.getX(), l.getY(), l.getZ()); }
 
-    private static List<ItemStack> fromNMS(RecipeItemStack in) { return Arrays.stream(in.choices).map(CraftItemStack::asBukkitCopy).collect(Collectors.toList()); }
+    private static List<ItemStack> fromNMS(RecipeItemStack in) {
+        in.buildChoices();
+        return Arrays.stream(in.choices).map(CraftItemStack::asBukkitCopy).collect(Collectors.toList());
+    }
 
     private static Sound fromNMS(SoundEffect s) {
         try {

--- a/1_15_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_15_R1.java
+++ b/1_15_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_15_R1.java
@@ -1688,7 +1688,7 @@ public class ChipUtil1_15_R1 implements ChipUtil {
                     Field f = clazz.getDeclaredField(name);
                     f.setAccessible(true);
                     return cast.cast(f.get(o));
-                } catch (NoSuchFieldException e) {
+                } catch (NoSuchFieldException | ClassCastException e) {
                     if (PathfinderGoal.class.isAssignableFrom(clazz.getSuperclass())) clazz = (Class<? extends PathfinderGoal>) clazz.getSuperclass();
                     else break;
                 }
@@ -1709,7 +1709,10 @@ public class ChipUtil1_15_R1 implements ChipUtil {
 
     private static BlockPosition toNMS(Location l) { return new BlockPosition(l.getX(), l.getY(), l.getZ()); }
 
-    private static List<ItemStack> fromNMS(RecipeItemStack in) { return Arrays.stream(in.choices).map(CraftItemStack::asBukkitCopy).collect(Collectors.toList()); }
+    private static List<ItemStack> fromNMS(RecipeItemStack in) {
+        in.buildChoices();
+        return Arrays.stream(in.choices).map(CraftItemStack::asBukkitCopy).collect(Collectors.toList());
+    }
 
     private static Sound fromNMS(SoundEffect s) {
         try {

--- a/1_16_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R1.java
+++ b/1_16_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R1.java
@@ -1716,7 +1716,7 @@ public class ChipUtil1_16_R1 implements ChipUtil {
                     Field f = clazz.getDeclaredField(name);
                     f.setAccessible(true);
                     return cast.cast(f.get(o));
-                } catch (NoSuchFieldException e) {
+                } catch (NoSuchFieldException | ClassCastException e) {
                     if (PathfinderGoal.class.isAssignableFrom(clazz.getSuperclass())) clazz = (Class<? extends PathfinderGoal>) clazz.getSuperclass();
                     else break;
                 }
@@ -1737,7 +1737,10 @@ public class ChipUtil1_16_R1 implements ChipUtil {
 
     private static BlockPosition toNMS(Location l) { return new BlockPosition(l.getX(), l.getY(), l.getZ()); }
 
-    private static List<ItemStack> fromNMS(RecipeItemStack in) { return Arrays.stream(in.choices).map(CraftItemStack::asBukkitCopy).collect(Collectors.toList()); }
+    private static List<ItemStack> fromNMS(RecipeItemStack in) {
+        in.buildChoices();
+        return Arrays.stream(in.choices).map(CraftItemStack::asBukkitCopy).collect(Collectors.toList());
+    }
 
     private static Sound fromNMS(SoundEffect s) {
         try {

--- a/1_16_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R2.java
+++ b/1_16_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R2.java
@@ -1715,7 +1715,7 @@ public class ChipUtil1_16_R2 implements ChipUtil {
                     Field f = clazz.getDeclaredField(name);
                     f.setAccessible(true);
                     return cast.cast(f.get(o));
-                } catch (NoSuchFieldException e) {
+                } catch (NoSuchFieldException | ClassCastException e) {
                     if (PathfinderGoal.class.isAssignableFrom(clazz.getSuperclass())) clazz = (Class<? extends PathfinderGoal>) clazz.getSuperclass();
                     else break;
                 }
@@ -1736,7 +1736,10 @@ public class ChipUtil1_16_R2 implements ChipUtil {
 
     private static BlockPosition toNMS(Location l) { return new BlockPosition(l.getX(), l.getY(), l.getZ()); }
 
-    private static List<ItemStack> fromNMS(RecipeItemStack in) { return Arrays.stream(in.choices).map(CraftItemStack::asBukkitCopy).collect(Collectors.toList()); }
+    private static List<ItemStack> fromNMS(RecipeItemStack in) {
+        in.buildChoices();
+        return Arrays.stream(in.choices).map(CraftItemStack::asBukkitCopy).collect(Collectors.toList());
+    }
 
     private static Sound fromNMS(SoundEffect s) {
         try {

--- a/1_16_R3/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R3.java
+++ b/1_16_R3/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R3.java
@@ -1715,7 +1715,7 @@ public class ChipUtil1_16_R3 implements ChipUtil {
                     Field f = clazz.getDeclaredField(name);
                     f.setAccessible(true);
                     return cast.cast(f.get(o));
-                } catch (NoSuchFieldException e) {
+                } catch (NoSuchFieldException | ClassCastException e) {
                     if (PathfinderGoal.class.isAssignableFrom(clazz.getSuperclass())) clazz = (Class<? extends PathfinderGoal>) clazz.getSuperclass();
                     else break;
                 }
@@ -1736,7 +1736,10 @@ public class ChipUtil1_16_R3 implements ChipUtil {
 
     private static BlockPosition toNMS(Location l) { return new BlockPosition(l.getX(), l.getY(), l.getZ()); }
 
-    private static List<ItemStack> fromNMS(RecipeItemStack in) { return Arrays.stream(in.choices).map(CraftItemStack::asBukkitCopy).collect(Collectors.toList()); }
+    private static List<ItemStack> fromNMS(RecipeItemStack in) {
+        in.buildChoices();
+        return Arrays.stream(in.choices).map(CraftItemStack::asBukkitCopy).collect(Collectors.toList());
+    }
 
     private static Sound fromNMS(SoundEffect s) { return CraftSound.getBukkit(s); }
 

--- a/1_17_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_17_R1.java
+++ b/1_17_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_17_R1.java
@@ -1696,7 +1696,7 @@ public final class ChipUtil1_17_R1 implements ChipUtil {
                     Field f = clazz.getDeclaredField(name);
                     f.setAccessible(true);
                     return cast.cast(f.get(o));
-                } catch (NoSuchFieldException e) {
+                } catch (NoSuchFieldException | ClassCastException e) {
                     if (PathfinderGoal.class.isAssignableFrom(clazz.getSuperclass())) clazz = (Class<? extends PathfinderGoal>) clazz.getSuperclass();
                     else break;
                 }

--- a/1_18_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R1.java
+++ b/1_18_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R1.java
@@ -1695,7 +1695,7 @@ public final class ChipUtil1_18_R1 implements ChipUtil {
                     Field f = clazz.getDeclaredField(name);
                     f.setAccessible(true);
                     return cast.cast(f.get(o));
-                } catch (NoSuchFieldException e) {
+                } catch (NoSuchFieldException | ClassCastException e) {
                     if (Goal.class.isAssignableFrom(clazz.getSuperclass())) clazz = (Class<? extends Goal>) clazz.getSuperclass();
                     else break;
                 }
@@ -1716,7 +1716,7 @@ public final class ChipUtil1_18_R1 implements ChipUtil {
 
     private static BlockPos toNMS(Location l) { return new BlockPos(l.getX(), l.getY(), l.getZ()); }
 
-    private static List<ItemStack> fromNMS(Ingredient in) { return Arrays.stream(in.itemStacks).map(CraftItemStack::asBukkitCopy).collect(Collectors.toList()); }
+    private static List<ItemStack> fromNMS(Ingredient in) { return Arrays.stream(in.getItems()).map(CraftItemStack::asBukkitCopy).collect(Collectors.toList()); }
 
     private static Sound fromNMS(SoundEvent s) { return CraftSound.getBukkit(s); }
 

--- a/1_18_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R2.java
+++ b/1_18_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R2.java
@@ -1695,7 +1695,7 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
                     Field f = clazz.getDeclaredField(name);
                     f.setAccessible(true);
                     return cast.cast(f.get(o));
-                } catch (NoSuchFieldException e) {
+                } catch (NoSuchFieldException | ClassCastException e) {
                     if (Goal.class.isAssignableFrom(clazz.getSuperclass())) clazz = (Class<? extends Goal>) clazz.getSuperclass();
                     else break;
                 }
@@ -1716,7 +1716,7 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
 
     private static BlockPos toNMS(Location l) { return new BlockPos(l.getX(), l.getY(), l.getZ()); }
 
-    private static List<ItemStack> fromNMS(Ingredient in) { return Arrays.stream(in.itemStacks).map(CraftItemStack::asBukkitCopy).collect(Collectors.toList()); }
+    private static List<ItemStack> fromNMS(Ingredient in) { return Arrays.stream(in.getItems()).map(CraftItemStack::asBukkitCopy).collect(Collectors.toList()); }
 
     private static Sound fromNMS(SoundEvent s) { return CraftSound.getBukkit(s); }
 

--- a/1_19_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_19_R1.java
+++ b/1_19_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_19_R1.java
@@ -1720,7 +1720,7 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
                     Field f = clazz.getDeclaredField(name);
                     f.setAccessible(true);
                     return cast.cast(f.get(o));
-                } catch (NoSuchFieldException e) {
+                } catch (NoSuchFieldException | ClassCastException e) {
                     if (Goal.class.isAssignableFrom(clazz.getSuperclass())) clazz = (Class<? extends Goal>) clazz.getSuperclass();
                     else break;
                 }
@@ -1741,7 +1741,7 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
 
     private static BlockPos toNMS(Location l) { return new BlockPos(l.getX(), l.getY(), l.getZ()); }
 
-    private static List<ItemStack> fromNMS(Ingredient in) { return Arrays.stream(in.itemStacks).map(CraftItemStack::asBukkitCopy).collect(Collectors.toList()); }
+    private static List<ItemStack> fromNMS(Ingredient in) { return Arrays.stream(in.getItems()).map(CraftItemStack::asBukkitCopy).collect(Collectors.toList()); }
 
     private static Sound fromNMS(SoundEvent s) { return CraftSound.getBukkit(s); }
 

--- a/base/src/main/java/me/gamercoder215/mobchip/ai/animation/EntityAnimation.java
+++ b/base/src/main/java/me/gamercoder215/mobchip/ai/animation/EntityAnimation.java
@@ -11,10 +11,6 @@ import org.jetbrains.annotations.Nullable;
 public enum EntityAnimation implements Keyed {
 
     /**
-     * Represents an Empty Animation
-     */
-    EMPTY(""),
-    /**
      * Represents the Damage Animation when taking damage
      */
     DAMAGE("hurt"),


### PR DESCRIPTION
## Info
This PR closes #8

## Details
As mentioned there, three different errors show up when trying to get the brain of different mobs. This PR makes a few short fixes so the errors no longer happen. See the [issue](https://github.com/GamerCoder215/MobChip/issues/8#issuecomment-1249818567) for a more in-depth description.

I did a little testing, and with this PR MobChip no longer throws errors, but I can't confirm it 100% works as I'm not familiar with how MobChip/pathfinders in general are supposed to work. Changes are only applied for `1_19_R1`.

## Tested Environments

### OS
OS: Debian 11

### Java / Minecraft
1.19 & 1.19.2

#### MC Builds
- [X] Tested on Latest Spigot Version
- [X] Tested on Latest Paper / Purpur Version

#### JDK Builds
Tested on:
- [ ] JDK Version 8/11
- [X] JDK Version 17/18

## Demonstration
N/A