### PR TITLE
Various fixes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@ OS:
 
 #### JDK Builds
 Tested on:
-- [ ] JDK Versuib 8/11
+- [ ] JDK Version 8/11
 - [ ] JDK Version 17/18
 
 ## Demonstration

--- a/1_13_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R1.java
+++ b/1_13_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R1.java
@@ -172,7 +172,9 @@ public final class ChipUtil1_13_R1 implements ChipUtil {
         Mob mob = b.getEntity();
         EntityInsentient m = toNMS(mob);
 
-        switch (b.getInternalName()) {
+        String name = b.getInternalName().startsWith("PathfinderGoal") ? b.getInternalName().replace("PathfinderGoal", "") : b.getInternalName();
+
+        switch (name) {
             case "AvoidTarget": {
                 PathfinderAvoidEntity<?> p = (PathfinderAvoidEntity<?>) b;
                 return new PathfinderGoalAvoidTarget<>((EntityCreature) m, toNMS(p.getFilter()), p.getMaxDistance(), p.getSpeedModifier(), p.getSprintModifier());
@@ -209,7 +211,7 @@ public final class ChipUtil1_13_R1 implements ChipUtil {
             }
             case "FollowParent": {
                 PathfinderFollowParent p = (PathfinderFollowParent) b;
-                return new PathfinderGoalFollowParent((EntityTameableAnimal) m, p.getSpeedModifier());
+                return new PathfinderGoalFollowParent((EntityAnimal) m, p.getSpeedModifier());
             }
             case "LeapAtTarget": {
                 PathfinderLeapAtTarget p = (PathfinderLeapAtTarget) b;
@@ -322,8 +324,6 @@ public final class ChipUtil1_13_R1 implements ChipUtil {
         Mob mob = b.getEntity();
         EntityInsentient m = toNMS(mob);
         PathfinderGoalSelector s = target ? m.targetSelector : m.goalSelector;
-
-        String name = b.getInternalName().startsWith("PathfinderGoal") ? b.getInternalName().replace("PathfinderGoal", "") : b.getInternalName();
 
         PathfinderGoal g = toNMS(b);
 

--- a/1_13_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R2.java
+++ b/1_13_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R2.java
@@ -172,7 +172,9 @@ public class ChipUtil1_13_R2 implements ChipUtil {
         Mob mob = b.getEntity();
         EntityInsentient m = toNMS(mob);
 
-        switch (b.getInternalName()) {
+        String name = b.getInternalName().startsWith("PathfinderGoal") ? b.getInternalName().replace("PathfinderGoal", "") : b.getInternalName();
+
+        switch (name) {
             case "AvoidTarget": {
                 PathfinderAvoidEntity<?> p = (PathfinderAvoidEntity<?>) b;
                 return new PathfinderGoalAvoidTarget<>((EntityCreature) m, toNMS(p.getFilter()), p.getMaxDistance(), p.getSpeedModifier(), p.getSprintModifier());
@@ -209,7 +211,7 @@ public class ChipUtil1_13_R2 implements ChipUtil {
             }
             case "FollowParent": {
                 PathfinderFollowParent p = (PathfinderFollowParent) b;
-                return new PathfinderGoalFollowParent((EntityTameableAnimal) m, p.getSpeedModifier());
+                return new PathfinderGoalFollowParent((EntityAnimal) m, p.getSpeedModifier());
             }
             case "LeapAtTarget": {
                 PathfinderLeapAtTarget p = (PathfinderLeapAtTarget) b;
@@ -323,8 +325,6 @@ public class ChipUtil1_13_R2 implements ChipUtil {
         Mob mob = b.getEntity();
         EntityInsentient m = toNMS(mob);
         PathfinderGoalSelector s = target ? m.targetSelector : m.goalSelector;
-
-        String name = b.getInternalName().startsWith("PathfinderGoal") ? b.getInternalName().replace("PathfinderGoal", "") : b.getInternalName();
 
         PathfinderGoal g = toNMS(b);
 

--- a/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_14_R1.java
+++ b/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_14_R1.java
@@ -162,7 +162,9 @@ public class ChipUtil1_14_R1 implements ChipUtil {
         Mob mob = b.getEntity();
         EntityInsentient m = toNMS(mob);
 
-        switch (b.getInternalName()) {
+        String name = b.getInternalName().startsWith("PathfinderGoal") ? b.getInternalName().replace("PathfinderGoal", "") : b.getInternalName();
+
+        switch (name) {
             case "AvoidTarget": {
                 PathfinderAvoidEntity<?> p = (PathfinderAvoidEntity<?>) b;
                 return new PathfinderGoalAvoidTarget<>((EntityCreature) m, toNMS(p.getFilter()), p.getMaxDistance(), p.getSpeedModifier(), p.getSprintModifier());
@@ -219,7 +221,7 @@ public class ChipUtil1_14_R1 implements ChipUtil {
             }
             case "FollowParent": {
                 PathfinderFollowParent p = (PathfinderFollowParent) b;
-                return new PathfinderGoalFollowParent((EntityTameableAnimal) m, p.getSpeedModifier());
+                return new PathfinderGoalFollowParent((EntityAnimal) m, p.getSpeedModifier());
             }
             case "JumpOnBlock": {
                 PathfinderCatOnBlock p = (PathfinderCatOnBlock) b;
@@ -360,8 +362,6 @@ public class ChipUtil1_14_R1 implements ChipUtil {
         Mob mob = b.getEntity();
         EntityInsentient m = toNMS(mob);
         PathfinderGoalSelector s = target ? m.targetSelector : m.goalSelector;
-
-        String name = b.getInternalName().startsWith("PathfinderGoal") ? b.getInternalName().replace("PathfinderGoal", "") : b.getInternalName();
 
         PathfinderGoal g = toNMS(b);
 

--- a/1_15_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_15_R1.java
+++ b/1_15_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_15_R1.java
@@ -143,7 +143,9 @@ public class ChipUtil1_15_R1 implements ChipUtil {
         Mob mob = b.getEntity();
         EntityInsentient m = toNMS(mob);
 
-        switch (b.getInternalName()) {
+        String name = b.getInternalName().startsWith("PathfinderGoal") ? b.getInternalName().replace("PathfinderGoal", "") : b.getInternalName();
+
+        switch (name) {
             case "AvoidTarget": {
                 PathfinderAvoidEntity<?> p = (PathfinderAvoidEntity<?>) b;
                 return new PathfinderGoalAvoidTarget<>((EntityCreature) m, toNMS(p.getFilter()), p.getMaxDistance(), p.getSpeedModifier(), p.getSprintModifier());
@@ -200,7 +202,7 @@ public class ChipUtil1_15_R1 implements ChipUtil {
             }
             case "FollowParent": {
                 PathfinderFollowParent p = (PathfinderFollowParent) b;
-                return new PathfinderGoalFollowParent((EntityTameableAnimal) m, p.getSpeedModifier());
+                return new PathfinderGoalFollowParent((EntityAnimal) m, p.getSpeedModifier());
             }
             case "JumpOnBlock": {
                 PathfinderCatOnBlock p = (PathfinderCatOnBlock) b;
@@ -342,7 +344,6 @@ public class ChipUtil1_15_R1 implements ChipUtil {
         EntityInsentient m = toNMS(mob);
         PathfinderGoalSelector s = target ? m.targetSelector : m.goalSelector;
 
-        String name = b.getInternalName().startsWith("PathfinderGoal") ? b.getInternalName().replace("PathfinderGoal", "") : b.getInternalName();
         PathfinderGoal g = toNMS(b);
 
         if (g == null) return;

--- a/1_16_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R1.java
+++ b/1_16_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R1.java
@@ -180,7 +180,9 @@ public class ChipUtil1_16_R1 implements ChipUtil {
         Mob mob = b.getEntity();
         EntityInsentient m = toNMS(mob);
 
-        switch (b.getInternalName()) {
+        String name = b.getInternalName().startsWith("PathfinderGoal") ? b.getInternalName().replace("PathfinderGoal", "") : b.getInternalName();
+
+        switch (name) {
             case "AvoidTarget": {
                 PathfinderAvoidEntity<?> p = (PathfinderAvoidEntity<?>) b;
                 return new PathfinderGoalAvoidTarget<>((EntityCreature) m, toNMS(p.getFilter()), p.getMaxDistance(), p.getSpeedModifier(), p.getSprintModifier());
@@ -237,7 +239,7 @@ public class ChipUtil1_16_R1 implements ChipUtil {
             }
             case "FollowParent": {
                 PathfinderFollowParent p = (PathfinderFollowParent) b;
-                return new PathfinderGoalFollowParent((EntityTameableAnimal) m, p.getSpeedModifier());
+                return new PathfinderGoalFollowParent((EntityAnimal) m, p.getSpeedModifier());
             }
             case "JumpOnBlock": {
                 PathfinderCatOnBlock p = (PathfinderCatOnBlock) b;
@@ -379,7 +381,6 @@ public class ChipUtil1_16_R1 implements ChipUtil {
         EntityInsentient m = toNMS(mob);
         PathfinderGoalSelector s = target ? m.targetSelector : m.goalSelector;
 
-        String name = b.getInternalName().startsWith("PathfinderGoal") ? b.getInternalName().replace("PathfinderGoal", "") : b.getInternalName();
         PathfinderGoal g = toNMS(b);
 
         if (g == null) return;

--- a/1_16_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R2.java
+++ b/1_16_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R2.java
@@ -142,7 +142,9 @@ public class ChipUtil1_16_R2 implements ChipUtil {
         Mob mob = b.getEntity();
         EntityInsentient m = toNMS(mob);
 
-        switch (b.getInternalName()) {
+        String name = b.getInternalName().startsWith("PathfinderGoal") ? b.getInternalName().replace("PathfinderGoal", "") : b.getInternalName();
+
+        switch (name) {
             case "AvoidTarget": {
                 PathfinderAvoidEntity<?> p = (PathfinderAvoidEntity<?>) b;
                 return new PathfinderGoalAvoidTarget<>((EntityCreature) m, toNMS(p.getFilter()), p.getMaxDistance(), p.getSpeedModifier(), p.getSprintModifier());
@@ -199,7 +201,7 @@ public class ChipUtil1_16_R2 implements ChipUtil {
             }
             case "FollowParent": {
                 PathfinderFollowParent p = (PathfinderFollowParent) b;
-                return new PathfinderGoalFollowParent((EntityTameableAnimal) m, p.getSpeedModifier());
+                return new PathfinderGoalFollowParent((EntityAnimal) m, p.getSpeedModifier());
             }
             case "JumpOnBlock": {
                 PathfinderCatOnBlock p = (PathfinderCatOnBlock) b;
@@ -341,7 +343,6 @@ public class ChipUtil1_16_R2 implements ChipUtil {
         EntityInsentient m = toNMS(mob);
         PathfinderGoalSelector s = target ? m.targetSelector : m.goalSelector;
 
-        String name = b.getInternalName().startsWith("PathfinderGoal") ? b.getInternalName().replace("PathfinderGoal", "") : b.getInternalName();
         PathfinderGoal g = toNMS(b);
 
         if (g == null) return;

--- a/1_16_R3/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R3.java
+++ b/1_16_R3/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R3.java
@@ -143,7 +143,9 @@ public class ChipUtil1_16_R3 implements ChipUtil {
         Mob mob = b.getEntity();
         EntityInsentient m = toNMS(mob);
 
-        switch (b.getInternalName()) {
+        String name = b.getInternalName().startsWith("PathfinderGoal") ? b.getInternalName().replace("PathfinderGoal", "") : b.getInternalName();
+
+        switch (name) {
             case "AvoidTarget": {
                 PathfinderAvoidEntity<?> p = (PathfinderAvoidEntity<?>) b;
                 return new PathfinderGoalAvoidTarget<>((EntityCreature) m, toNMS(p.getFilter()), p.getMaxDistance(), p.getSpeedModifier(), p.getSprintModifier());
@@ -200,7 +202,7 @@ public class ChipUtil1_16_R3 implements ChipUtil {
             }
             case "FollowParent": {
                 PathfinderFollowParent p = (PathfinderFollowParent) b;
-                return new PathfinderGoalFollowParent((EntityTameableAnimal) m, p.getSpeedModifier());
+                return new PathfinderGoalFollowParent((EntityAnimal) m, p.getSpeedModifier());
             }
             case "JumpOnBlock": {
                 PathfinderCatOnBlock p = (PathfinderCatOnBlock) b;
@@ -339,7 +341,6 @@ public class ChipUtil1_16_R3 implements ChipUtil {
         EntityInsentient m = toNMS(mob);
         PathfinderGoalSelector s = target ? m.targetSelector : m.goalSelector;
 
-        String name = b.getInternalName().startsWith("PathfinderGoal") ? b.getInternalName().replace("PathfinderGoal", "") : b.getInternalName();
         PathfinderGoal g = toNMS(b);
 
         if (g == null) return;

--- a/1_17_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_17_R1.java
+++ b/1_17_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_17_R1.java
@@ -185,7 +185,9 @@ public final class ChipUtil1_17_R1 implements ChipUtil {
         Mob mob = b.getEntity();
         EntityInsentient m = toNMS(mob);
 
-        return switch (b.getInternalName()) {
+        String name = b.getInternalName().startsWith("PathfinderGoal") ? b.getInternalName().replace("PathfinderGoal", "") : b.getInternalName();
+
+        return switch (name) {
             case "AvoidTarget" -> {
                 PathfinderAvoidEntity<?> p = (PathfinderAvoidEntity<?>) b;
                 yield new PathfinderGoalAvoidTarget<>((EntityCreature) m, toNMS(p.getFilter()), p.getMaxDistance(), p.getSpeedModifier(), p.getSprintModifier());
@@ -241,7 +243,7 @@ public final class ChipUtil1_17_R1 implements ChipUtil {
             }
             case "FollowParent" -> {
                 PathfinderFollowParent p = (PathfinderFollowParent) b;
-                yield new PathfinderGoalFollowParent((EntityTameableAnimal) m, p.getSpeedModifier());
+                yield new PathfinderGoalFollowParent((EntityAnimal) m, p.getSpeedModifier());
             }
             case "JumpOnBlock" -> {
                 PathfinderCatOnBlock p = (PathfinderCatOnBlock) b;
@@ -391,8 +393,6 @@ public final class ChipUtil1_17_R1 implements ChipUtil {
         Mob mob = b.getEntity();
         EntityInsentient m = toNMS(mob);
         PathfinderGoalSelector s = target ? m.bP : m.bO;
-
-        String name = b.getInternalName().startsWith("PathfinderGoal") ? b.getInternalName().replace("PathfinderGoal", "") : b.getInternalName();
 
         final PathfinderGoal g = toNMS(b);
 

--- a/1_18_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R1.java
+++ b/1_18_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R1.java
@@ -178,7 +178,9 @@ public final class ChipUtil1_18_R1 implements ChipUtil {
         Mob mob = b.getEntity();
         net.minecraft.world.entity.Mob m = toNMS(mob);
 
-        return switch (b.getInternalName()) {
+        String name = b.getInternalName().startsWith("PathfinderGoal") ? b.getInternalName().replace("PathfinderGoal", "") : b.getInternalName();
+
+        return switch (name) {
             case "AvoidTarget" -> {
                 PathfinderAvoidEntity<?> p = (PathfinderAvoidEntity<?>) b;
                 yield new AvoidEntityGoal<>((PathfinderMob) m, toNMS(p.getFilter()), p.getMaxDistance(), p.getSpeedModifier(), p.getSprintModifier());
@@ -234,7 +236,7 @@ public final class ChipUtil1_18_R1 implements ChipUtil {
             }
             case "FollowParent" -> {
                 PathfinderFollowParent p = (PathfinderFollowParent) b;
-                yield new FollowParentGoal((TamableAnimal) m, p.getSpeedModifier());
+                yield new FollowParentGoal((net.minecraft.world.entity.animal.Animal) m, p.getSpeedModifier());
             }
             case "JumpOnBlock" -> {
                 PathfinderCatOnBlock p = (PathfinderCatOnBlock) b;
@@ -384,8 +386,6 @@ public final class ChipUtil1_18_R1 implements ChipUtil {
         Mob mob = b.getEntity();
         net.minecraft.world.entity.Mob m = toNMS(mob);
         GoalSelector s = target ? m.targetSelector : m.goalSelector;
-
-        String name = b.getInternalName().startsWith("PathfinderGoal") ? b.getInternalName().replace("PathfinderGoal", "") : b.getInternalName();
 
         final Goal g = toNMS(b);
 

--- a/1_18_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R2.java
+++ b/1_18_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R2.java
@@ -178,7 +178,9 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
         Mob mob = b.getEntity();
         net.minecraft.world.entity.Mob m = toNMS(mob);
 
-        return switch (b.getInternalName()) {
+        String name = b.getInternalName().startsWith("PathfinderGoal") ? b.getInternalName().replace("PathfinderGoal", "") : b.getInternalName();
+
+        return switch (name) {
             case "AvoidTarget" -> {
                 PathfinderAvoidEntity<?> p = (PathfinderAvoidEntity<?>) b;
                 yield new AvoidEntityGoal<>((PathfinderMob) m, toNMS(p.getFilter()), p.getMaxDistance(), p.getSpeedModifier(), p.getSprintModifier());
@@ -238,7 +240,7 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
             }
             case "FollowParent" -> {
                 PathfinderFollowParent p = (PathfinderFollowParent) b;
-                yield new FollowParentGoal((TamableAnimal) m, p.getSpeedModifier());
+                yield new FollowParentGoal((net.minecraft.world.entity.animal.Animal) m, p.getSpeedModifier());
             }
             case "JumpOnBlock" -> {
                 PathfinderCatOnBlock p = (PathfinderCatOnBlock) b;
@@ -385,8 +387,6 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
         Mob mob = b.getEntity();
         net.minecraft.world.entity.Mob m = toNMS(mob);
         GoalSelector s = target ? m.targetSelector : m.goalSelector;
-
-        String name = b.getInternalName().startsWith("PathfinderGoal") ? b.getInternalName().replace("PathfinderGoal", "") : b.getInternalName();
 
         final Goal g = toNMS(b);
         if (g == null) return;

--- a/1_19_R1/pom.xml
+++ b/1_19_R1/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <java.version>17</java.version>
 
-        <minecraft.version>1.19-R0.1-SNAPSHOT</minecraft.version>
+        <minecraft.version>1.19.2-R0.1-SNAPSHOT</minecraft.version>
     </properties>
 
     <build>

--- a/1_19_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_19_R1.java
+++ b/1_19_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_19_R1.java
@@ -54,6 +54,7 @@ import net.minecraft.world.entity.ai.memory.WalkTarget;
 import net.minecraft.world.entity.ai.navigation.PathNavigation;
 import net.minecraft.world.entity.ai.targeting.TargetingConditions;
 import net.minecraft.world.entity.animal.AbstractSchoolingFish;
+import net.minecraft.world.entity.animal.Animal;
 import net.minecraft.world.entity.animal.ShoulderRidingEntity;
 import net.minecraft.world.entity.animal.allay.AllayAi;
 import net.minecraft.world.entity.animal.axolotl.AxolotlAi;
@@ -180,7 +181,9 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
         Mob mob = b.getEntity();
         net.minecraft.world.entity.Mob m = toNMS(mob);
 
-        return switch (b.getInternalName()) {
+        String name = b.getInternalName().startsWith("PathfinderGoal") ? b.getInternalName().replace("PathfinderGoal", "") : b.getInternalName();
+
+        return switch (name) {
             case "AvoidTarget" -> {
                 PathfinderAvoidEntity<?> p = (PathfinderAvoidEntity<?>) b;
                 yield new AvoidEntityGoal<>((PathfinderMob) m, toNMS(p.getFilter()), p.getMaxDistance(), p.getSpeedModifier(), p.getSprintModifier());
@@ -243,7 +246,7 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
             }
             case "FollowParent" -> {
                 PathfinderFollowParent p = (PathfinderFollowParent) b;
-                yield new FollowParentGoal((TamableAnimal) m, p.getSpeedModifier());
+                yield new FollowParentGoal((Animal) m, p.getSpeedModifier());
             }
             case "JumpOnBlock" -> {
                 PathfinderCatOnBlock p = (PathfinderCatOnBlock) b;
@@ -393,8 +396,6 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
         Mob mob = b.getEntity();
         net.minecraft.world.entity.Mob m = toNMS(mob);
         GoalSelector s = target ? m.targetSelector : m.goalSelector;
-
-        String name = b.getInternalName().startsWith("PathfinderGoal") ? b.getInternalName().replace("PathfinderGoal", "") : b.getInternalName();
 
         final Goal g = toNMS(b);
         if (g == null) return;


### PR DESCRIPTION
## Info
This PR fixes a couple more problems I've encountered while using MobChip.

## Details
1. FollowParentGoal pathfinder accepts all `Animal`s, not just tameable ones. The previously narrow cast occasionally caused errors. Fixed in all version modules.
2. Bumped 1_19_R1 remapping version to 1.19.2 due to LivingEntity#getBrain() mapping changing: `dz` -> `dy`.
3. Fixed `toNMS(Pathfinder)` so it correctly removes `PathfinderGoal` from the name before switching on it. Fixed in all version modules.

## Tested Environments

### OS
OS: Debian 11

### Java / Minecraft

#### MC Builds
- [ ] Tested on Latest Spigot Version
- [X] Tested on Latest Paper / Purpur Version

#### JDK Builds
Tested on:
- [ ] JDK Version 8/11
- [X] JDK Version 17/18

## Demonstration
Errors fixed:
### 1
```
java.lang.ClassCastException: class net.minecraft.world.entity.animal.EntityPig cannot be cast to class net.minecraft.world.entity.EntityTameableAnimal (net.minecraft.world.entity.animal.EntityPig and net.m
inecraft.world.entity.EntityTameableAnimal are in unnamed module of loader java.net.URLClassLoader @25f38edc)
        at me.gamercoder215.mobchip.abstraction.ChipUtil1_19_R1.toNMS(ChipUtil1_19_R1.java:248) ~[floopin.jar:?]
        at me.gamercoder215.mobchip.abstraction.ChipUtil1_19_R1.addPathfinder(ChipUtil1_19_R1.java:399) ~[floopin.jar:?]
        at me.gamercoder215.mobchip.abstraction.ChipUtil.addPathfinders(ChipUtil.java:53) ~[floopin.jar:?]
        at me.gamercoder215.mobchip.bukkit.BukkitAI.updateAI(BukkitAI.java:43) ~[floopin.jar:?]
        at me.gamercoder215.mobchip.bukkit.BukkitAI.add(BukkitAI.java:113) ~[floopin.jar:?]
        at me.gamercoder215.mobchip.bukkit.BukkitAI.put(BukkitAI.java:70) ~[floopin.jar:?]
        at me.datatags.floopin.Floopin.onClick(Floopin.java:66) ~[floopin.jar:?]
```
### 2
```
java.lang.NoSuchMethodError: 'net.minecraft.world.entity.ai.BehaviorController net.minecraft.world.entity.EntityInsentient.dz()'
        at be.isach.ultracosmetics.shaded.mobchip.abstraction.ChipUtil1_19_R1.removeMemory(ChipUtil1_19_R1.java:1519) ~[UltraCosmetics-2.9-RELEASE.jar:?]
        at be.isach.ultracosmetics.shaded.mobchip.bukkit.BukkitBrain.removeMemory(BukkitBrain.java:227) ~[UltraCosmetics-2.9-RELEASE.jar:?]
        at java.lang.Iterable.forEach(Iterable.java:75) ~[?:?]
        at be.isach.ultracosmetics.cosmetics.pets.Pet.onEquip(Pet.java:112) ~[UltraCosmetics-2.9-RELEASE.jar:?]
```
### 3
(Can't find the stack trace for this one but I'm pretty sure it was causing errors)