### PR TITLE
Add methods for yaw, pitch, and step height

### DIFF
--- a/1_13_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R1.java
+++ b/1_13_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R1.java
@@ -823,7 +823,7 @@ public final class ChipUtil1_13_R1 implements ChipUtil {
 
         @Override
         public void setBodyRotation(float rotation) {
-            nmsMob.aQ = rotation > 360 ? (rotation - (float) (360 * Math.floor(rotation / 360))) : rotation;
+            nmsMob.aQ = normalizeRotation(rotation);
         }
 
         @Override
@@ -833,7 +833,7 @@ public final class ChipUtil1_13_R1 implements ChipUtil {
 
         @Override
         public void setHeadRotation(float rotation) {
-            nmsMob.aS = rotation > 360 ? (rotation - (float) (360 * Math.floor(rotation / 360))) : rotation;
+            nmsMob.aS = normalizeRotation(rotation);
         }
 
         @Override
@@ -957,6 +957,36 @@ public final class ChipUtil1_13_R1 implements ChipUtil {
         @Override
         public boolean isPushableBy(@Nullable Entity entity) {
             return IEntitySelector.a(toNMS(entity)).test(toNMS(entity));
+        }
+
+        @Override
+        public float getYaw() {
+            return nmsMob.yaw;
+        }
+
+        @Override
+        public void setYaw(float rotation) {
+            nmsMob.yaw = normalizeRotation(rotation);
+        }
+
+        @Override
+        public float getPitch() {
+            return nmsMob.pitch;
+        }
+
+        @Override
+        public void setPitch(float rotation) {
+            nmsMob.pitch = normalizeRotation(rotation);
+        }
+
+        @Override
+        public float getMaxUpStep() {
+            return nmsMob.K;
+        }
+
+        @Override
+        public void setMaxUpStep(float maxUpStep) {
+            nmsMob.K = maxUpStep;
         }
     }
 

--- a/1_13_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R1.java
+++ b/1_13_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R1.java
@@ -1395,7 +1395,9 @@ public final class ChipUtil1_13_R1 implements ChipUtil {
         for (Class<?> c : nms) {
 
             Class<? extends Entity> bukkit = fromNMS((Class<? extends net.minecraft.server.v1_13_R1.Entity>) c, Entity.class);
-            for (EntityType t : EntityType.values()) if (t.getEntityClass().isAssignableFrom(bukkit)) types.add(t);
+            for (EntityType t : EntityType.values()) {
+                if (t.getEntityClass() != null && t.getEntityClass().isAssignableFrom(bukkit)) types.add(t);
+            }
         }
         return types.toArray(new EntityType[0]);
     }

--- a/1_13_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R2.java
+++ b/1_13_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R2.java
@@ -1381,7 +1381,9 @@ public class ChipUtil1_13_R2 implements ChipUtil {
         for (Class<?> c : nms) {
 
             Class<? extends Entity> bukkit = fromNMS((Class<? extends net.minecraft.server.v1_13_R2.Entity>) c, Entity.class);
-            for (EntityType t : EntityType.values()) if (t.getEntityClass().isAssignableFrom(bukkit)) types.add(t);
+            for (EntityType t : EntityType.values()) {
+                if (t.getEntityClass() != null && t.getEntityClass().isAssignableFrom(bukkit)) types.add(t);
+            }
         }
         return types.toArray(new EntityType[0]);
     }

--- a/1_13_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R2.java
+++ b/1_13_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R2.java
@@ -824,7 +824,7 @@ public class ChipUtil1_13_R2 implements ChipUtil {
 
         @Override
         public void setBodyRotation(float rotation) {
-            nmsMob.aQ = rotation > 360 ? (rotation - (float) (360 * Math.floor(rotation / 360))) : rotation;
+            nmsMob.aQ = normalizeRotation(rotation);
         }
 
         @Override
@@ -834,7 +834,7 @@ public class ChipUtil1_13_R2 implements ChipUtil {
 
         @Override
         public void setHeadRotation(float rotation) {
-            nmsMob.aS = rotation > 360 ? (rotation - (float) (360 * Math.floor(rotation / 360))) : rotation;
+            nmsMob.aS = normalizeRotation(rotation);
         }
 
         @Override
@@ -959,6 +959,36 @@ public class ChipUtil1_13_R2 implements ChipUtil {
         @Override
         public boolean isPushableBy(@Nullable Entity entity) {
             return IEntitySelector.a(toNMS(entity)).test(toNMS(entity));
+        }
+
+        @Override
+        public float getYaw() {
+            return nmsMob.yaw;
+        }
+
+        @Override
+        public void setYaw(float rotation) {
+            nmsMob.yaw = normalizeRotation(rotation);
+        }
+
+        @Override
+        public float getPitch() {
+            return nmsMob.pitch;
+        }
+
+        @Override
+        public void setPitch(float rotation) {
+            nmsMob.pitch = normalizeRotation(rotation);
+        }
+
+        @Override
+        public float getMaxUpStep() {
+            return nmsMob.K;
+        }
+
+        @Override
+        public void setMaxUpStep(float maxUpStep) {
+            nmsMob.K = maxUpStep;
         }
     }
 

--- a/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_14_R1.java
+++ b/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_14_R1.java
@@ -1665,7 +1665,9 @@ public class ChipUtil1_14_R1 implements ChipUtil {
         for (Class<?> c : nms) {
 
             Class<? extends Entity> bukkit = fromNMS((Class<? extends net.minecraft.server.v1_14_R1.Entity>) c, Entity.class);
-            for (EntityType t : EntityType.values()) if (t.getEntityClass().isAssignableFrom(bukkit)) types.add(t);
+            for (EntityType t : EntityType.values()) {
+                if (t.getEntityClass() != null && t.getEntityClass().isAssignableFrom(bukkit)) types.add(t);
+            }
         }
         return types.toArray(new EntityType[0]);
     }

--- a/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_14_R1.java
+++ b/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_14_R1.java
@@ -907,7 +907,7 @@ public class ChipUtil1_14_R1 implements ChipUtil {
 
         @Override
         public void setBodyRotation(float rotation) {
-            nmsMob.aL = rotation > 360 ? (rotation - (float) (360 * Math.floor(rotation / 360))) : rotation;
+            nmsMob.aL = normalizeRotation(rotation);
         }
 
         @Override
@@ -917,7 +917,7 @@ public class ChipUtil1_14_R1 implements ChipUtil {
 
         @Override
         public void setHeadRotation(float rotation) {
-            nmsMob.aN = rotation > 360 ? (rotation - (float) (360 * Math.floor(rotation / 360))) : rotation;
+            nmsMob.aN = normalizeRotation(rotation);
         }
 
         @Override
@@ -1048,6 +1048,36 @@ public class ChipUtil1_14_R1 implements ChipUtil {
         @Override
         public boolean isPushableBy(@Nullable Entity entity) {
             return IEntitySelector.a(toNMS(entity)).test(toNMS(entity));
+        }
+
+        @Override
+        public float getYaw() {
+            return nmsMob.yaw;
+        }
+
+        @Override
+        public void setYaw(float rotation) {
+            nmsMob.yaw = normalizeRotation(rotation);
+        }
+
+        @Override
+        public float getPitch() {
+            return nmsMob.pitch;
+        }
+
+        @Override
+        public void setPitch(float rotation) {
+            nmsMob.pitch = normalizeRotation(rotation);
+        }
+
+        @Override
+        public float getMaxUpStep() {
+            return nmsMob.K;
+        }
+
+        @Override
+        public void setMaxUpStep(float maxUpStep) {
+            nmsMob.K = maxUpStep;
         }
     }
 

--- a/1_15_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_15_R1.java
+++ b/1_15_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_15_R1.java
@@ -908,7 +908,7 @@ public class ChipUtil1_15_R1 implements ChipUtil {
 
         @Override
         public void setBodyRotation(float rotation) {
-            nmsMob.aI = rotation > 360 ? (rotation - (float) (360 * Math.floor(rotation / 360))) : rotation;
+            nmsMob.aI = normalizeRotation(rotation);
         }
 
         @Override
@@ -918,7 +918,7 @@ public class ChipUtil1_15_R1 implements ChipUtil {
 
         @Override
         public void setHeadRotation(float rotation) {
-            nmsMob.aK = rotation > 360 ? (rotation - (float) (360 * Math.floor(rotation / 360))) : rotation;
+            nmsMob.aK = normalizeRotation(rotation);
         }
 
         @Override
@@ -1049,6 +1049,36 @@ public class ChipUtil1_15_R1 implements ChipUtil {
         @Override
         public boolean isPushableBy(@Nullable Entity entity) {
             return IEntitySelector.a(toNMS(entity)).test(toNMS(entity));
+        }
+
+        @Override
+        public float getYaw() {
+            return nmsMob.yaw;
+        }
+
+        @Override
+        public void setYaw(float rotation) {
+            nmsMob.yaw = normalizeRotation(rotation);
+        }
+
+        @Override
+        public float getPitch() {
+            return nmsMob.pitch;
+        }
+
+        @Override
+        public void setPitch(float rotation) {
+            nmsMob.pitch = normalizeRotation(rotation);
+        }
+
+        @Override
+        public float getMaxUpStep() {
+            return nmsMob.H;
+        }
+
+        @Override
+        public void setMaxUpStep(float maxUpStep) {
+            nmsMob.H = maxUpStep;
         }
     }
 

--- a/1_15_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_15_R1.java
+++ b/1_15_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_15_R1.java
@@ -1659,7 +1659,9 @@ public class ChipUtil1_15_R1 implements ChipUtil {
         for (Class<?> c : nms) {
 
             Class<? extends Entity> bukkit = fromNMS((Class<? extends net.minecraft.server.v1_15_R1.Entity>) c, Entity.class);
-            for (EntityType t : EntityType.values()) if (t.getEntityClass().isAssignableFrom(bukkit)) types.add(t);
+            for (EntityType t : EntityType.values()) {
+                if (t.getEntityClass() != null && t.getEntityClass().isAssignableFrom(bukkit)) types.add(t);
+            }
         }
         return types.toArray(new EntityType[0]);
     }

--- a/1_16_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R1.java
+++ b/1_16_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R1.java
@@ -949,7 +949,7 @@ public class ChipUtil1_16_R1 implements ChipUtil {
 
         @Override
         public void setBodyRotation(float rotation) {
-            nmsMob.aH = rotation > 360 ? (rotation - (float) (360 * Math.floor(rotation / 360))) : rotation;
+            nmsMob.aH = normalizeRotation(rotation);
         }
 
         @Override
@@ -959,7 +959,7 @@ public class ChipUtil1_16_R1 implements ChipUtil {
 
         @Override
         public void setHeadRotation(float rotation) {
-            nmsMob.aJ = rotation > 360 ? (rotation - (float) (360 * Math.floor(rotation / 360))) : rotation;
+            nmsMob.aJ = normalizeRotation(rotation);
         }
 
         @Override
@@ -1092,6 +1092,36 @@ public class ChipUtil1_16_R1 implements ChipUtil {
         @Override
         public boolean isPushableBy(@Nullable Entity entity) {
             return IEntitySelector.a(toNMS(entity)).test(toNMS(entity));
+        }
+
+        @Override
+        public float getYaw() {
+            return nmsMob.yaw;
+        }
+
+        @Override
+        public void setYaw(float rotation) {
+            nmsMob.yaw = normalizeRotation(rotation);
+        }
+
+        @Override
+        public float getPitch() {
+            return nmsMob.pitch;
+        }
+
+        @Override
+        public void setPitch(float rotation) {
+            nmsMob.pitch = normalizeRotation(rotation);
+        }
+
+        @Override
+        public float getMaxUpStep() {
+            return nmsMob.G;
+        }
+
+        @Override
+        public void setMaxUpStep(float maxUpStep) {
+            nmsMob.G = maxUpStep;
         }
     }
 

--- a/1_16_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R1.java
+++ b/1_16_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R1.java
@@ -1687,7 +1687,9 @@ public class ChipUtil1_16_R1 implements ChipUtil {
         for (Class<?> c : nms) {
 
             Class<? extends Entity> bukkit = fromNMS((Class<? extends net.minecraft.server.v1_16_R1.Entity>) c, Entity.class);
-            for (EntityType t : EntityType.values()) if (t.getEntityClass().isAssignableFrom(bukkit)) types.add(t);
+            for (EntityType t : EntityType.values()) {
+                if (t.getEntityClass() != null && t.getEntityClass().isAssignableFrom(bukkit)) types.add(t);
+            }
         }
         return types.toArray(new EntityType[0]);
     }

--- a/1_16_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R2.java
+++ b/1_16_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R2.java
@@ -911,7 +911,7 @@ public class ChipUtil1_16_R2 implements ChipUtil {
 
         @Override
         public void setBodyRotation(float rotation) {
-            nmsMob.aA = rotation > 360 ? (rotation - (float) (360 * Math.floor(rotation / 360))) : rotation;
+            nmsMob.aA = normalizeRotation(rotation);
         }
 
         @Override
@@ -921,7 +921,7 @@ public class ChipUtil1_16_R2 implements ChipUtil {
 
         @Override
         public void setHeadRotation(float rotation) {
-            nmsMob.aC = rotation > 360 ? (rotation - (float) (360 * Math.floor(rotation / 360))) : rotation;
+            nmsMob.aC = normalizeRotation(rotation);
         }
 
         @Override
@@ -1054,6 +1054,36 @@ public class ChipUtil1_16_R2 implements ChipUtil {
         @Override
         public boolean isPushableBy(@Nullable Entity entity) {
             return IEntitySelector.a(toNMS(entity)).test(toNMS(entity));
+        }
+
+        @Override
+        public float getYaw() {
+            return nmsMob.yaw;
+        }
+
+        @Override
+        public void setYaw(float rotation) {
+            nmsMob.yaw = normalizeRotation(rotation);
+        }
+
+        @Override
+        public float getPitch() {
+            return nmsMob.pitch;
+        }
+
+        @Override
+        public void setPitch(float rotation) {
+            nmsMob.pitch = normalizeRotation(rotation);
+        }
+
+        @Override
+        public float getMaxUpStep() {
+            return nmsMob.G;
+        }
+
+        @Override
+        public void setMaxUpStep(float maxUpStep) {
+            nmsMob.G = maxUpStep;
         }
     }
 

--- a/1_16_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R2.java
+++ b/1_16_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R2.java
@@ -1686,7 +1686,9 @@ public class ChipUtil1_16_R2 implements ChipUtil {
         for (Class<?> c : nms) {
 
             Class<? extends Entity> bukkit = fromNMS((Class<? extends net.minecraft.server.v1_16_R2.Entity>) c, Entity.class);
-            for (EntityType t : EntityType.values()) if (t.getEntityClass().isAssignableFrom(bukkit)) types.add(t);
+            for (EntityType t : EntityType.values()) {
+                if (t.getEntityClass() != null && t.getEntityClass().isAssignableFrom(bukkit)) types.add(t);
+            }
         }
         return types.toArray(new EntityType[0]);
     }

--- a/1_16_R3/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R3.java
+++ b/1_16_R3/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R3.java
@@ -911,7 +911,7 @@ public class ChipUtil1_16_R3 implements ChipUtil {
 
         @Override
         public void setBodyRotation(float rotation) {
-            nmsMob.aA = rotation > 360 ? (rotation - (float) (360 * Math.floor(rotation / 360))) : rotation;
+            nmsMob.aA = normalizeRotation(rotation);
         }
 
         @Override
@@ -921,7 +921,7 @@ public class ChipUtil1_16_R3 implements ChipUtil {
 
         @Override
         public void setHeadRotation(float rotation) {
-            nmsMob.aC = rotation > 360 ? (rotation - (float) (360 * Math.floor(rotation / 360))) : rotation;
+            nmsMob.aC = normalizeRotation(rotation);
         }
 
         @Override
@@ -1054,6 +1054,36 @@ public class ChipUtil1_16_R3 implements ChipUtil {
         @Override
         public boolean isPushableBy(@Nullable Entity entity) {
             return IEntitySelector.a(toNMS(entity)).test(toNMS(entity));
+        }
+
+        @Override
+        public float getYaw() {
+            return nmsMob.yaw;
+        }
+
+        @Override
+        public void setYaw(float rotation) {
+            nmsMob.yaw = normalizeRotation(rotation);
+        }
+
+        @Override
+        public float getPitch() {
+            return nmsMob.pitch;
+        }
+
+        @Override
+        public void setPitch(float rotation) {
+            nmsMob.pitch = normalizeRotation(rotation);
+        }
+
+        @Override
+        public float getMaxUpStep() {
+            return nmsMob.G;
+        }
+
+        @Override
+        public void setMaxUpStep(float maxUpStep) {
+            nmsMob.G = maxUpStep;
         }
     }
 

--- a/1_16_R3/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R3.java
+++ b/1_16_R3/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R3.java
@@ -1686,7 +1686,9 @@ public class ChipUtil1_16_R3 implements ChipUtil {
         for (Class<?> c : nms) {
 
             Class<? extends Entity> bukkit = fromNMS((Class<? extends net.minecraft.server.v1_16_R3.Entity>) c, Entity.class);
-            for (EntityType t : EntityType.values()) if (t.getEntityClass().isAssignableFrom(bukkit)) types.add(t);
+            for (EntityType t : EntityType.values()) {
+                if (t.getEntityClass() != null && t.getEntityClass().isAssignableFrom(bukkit)) types.add(t);
+            }
         }
         return types.toArray(new EntityType[0]);
     }

--- a/1_17_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_17_R1.java
+++ b/1_17_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_17_R1.java
@@ -941,7 +941,7 @@ public final class ChipUtil1_17_R1 implements ChipUtil {
 
         @Override
         public void setBodyRotation(float rotation) {
-            nmsMob.aX = rotation > 360 ? (rotation - (float) (360 * Math.floor(rotation / 360))) : rotation;
+            nmsMob.aX = normalizeRotation(rotation);
         }
 
         @Override
@@ -951,7 +951,7 @@ public final class ChipUtil1_17_R1 implements ChipUtil {
 
         @Override
         public void setHeadRotation(float rotation) {
-            nmsMob.aZ = rotation > 360 ? (rotation - (float) (360 * Math.floor(rotation / 360))) : rotation;
+            nmsMob.aZ = normalizeRotation(rotation);
         }
 
         @Override
@@ -1078,6 +1078,36 @@ public final class ChipUtil1_17_R1 implements ChipUtil {
         @Override
         public boolean isPushableBy(@Nullable Entity entity) {
             return IEntitySelector.a(toNMS(entity)).test(toNMS(entity));
+        }
+
+        @Override
+        public float getYaw() {
+            return nmsMob.getYRot();
+        }
+
+        @Override
+        public void setYaw(float rotation) {
+            nmsMob.setYRot(normalizeRotation(rotation));
+        }
+
+        @Override
+        public float getPitch() {
+            return nmsMob.getXRot();
+        }
+
+        @Override
+        public void setPitch(float rotation) {
+            nmsMob.setXRot(normalizeRotation(rotation));
+        }
+
+        @Override
+        public float getMaxUpStep() {
+            return nmsMob.O;
+        }
+
+        @Override
+        public void setMaxUpStep(float maxUpStep) {
+            nmsMob.O = maxUpStep;
         }
     }
 

--- a/1_17_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_17_R1.java
+++ b/1_17_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_17_R1.java
@@ -1660,7 +1660,9 @@ public final class ChipUtil1_17_R1 implements ChipUtil {
         for (Class<?> c : nms) {
 
             Class<? extends Entity> bukkit = fromNMS((Class<? extends net.minecraft.world.entity.Entity>) c, Entity.class);
-            for (EntityType t : EntityType.values()) if (t.getEntityClass().isAssignableFrom(bukkit)) types.add(t);
+            for (EntityType t : EntityType.values()) {
+                if (t.getEntityClass() != null && t.getEntityClass().isAssignableFrom(bukkit)) types.add(t);
+            }
         }
         return types.toArray(new EntityType[0]);
     }

--- a/1_18_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R1.java
+++ b/1_18_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R1.java
@@ -1659,7 +1659,9 @@ public final class ChipUtil1_18_R1 implements ChipUtil {
         for (Class<?> c : nms) {
 
             Class<? extends Entity> bukkit = fromNMS((Class<? extends net.minecraft.world.entity.Entity>) c, Entity.class);
-            for (EntityType t : EntityType.values()) if (t.getEntityClass().isAssignableFrom(bukkit)) types.add(t);
+            for (EntityType t : EntityType.values()) {
+                if (t.getEntityClass() != null && t.getEntityClass().isAssignableFrom(bukkit)) types.add(t);
+            }
         }
         return types.toArray(new EntityType[0]);
     }

--- a/1_18_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R1.java
+++ b/1_18_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R1.java
@@ -940,7 +940,7 @@ public final class ChipUtil1_18_R1 implements ChipUtil {
 
         @Override
         public void setBodyRotation(float rotation) {
-            nmsMob.yBodyRot = rotation > 360 ? (rotation - (float) (360 * Math.floor(rotation / 360))) : rotation;
+            nmsMob.yBodyRot = normalizeRotation(rotation);
         }
 
         @Override
@@ -950,7 +950,7 @@ public final class ChipUtil1_18_R1 implements ChipUtil {
 
         @Override
         public void setHeadRotation(float rotation) {
-            nmsMob.yHeadRot = rotation > 360 ? (rotation - (float) (360 * Math.floor(rotation / 360))) : rotation;
+            nmsMob.yHeadRot = normalizeRotation(rotation);
         }
 
         @Override
@@ -1077,6 +1077,36 @@ public final class ChipUtil1_18_R1 implements ChipUtil {
         @Override
         public boolean isPushableBy(@Nullable Entity entity) {
             return EntitySelector.pushableBy(toNMS(entity)).test(toNMS(entity));
+        }
+
+        @Override
+        public float getYaw() {
+            return nmsMob.getYRot();
+        }
+
+        @Override
+        public void setYaw(float rotation) {
+            nmsMob.setYRot(normalizeRotation(rotation));
+        }
+
+        @Override
+        public float getPitch() {
+            return nmsMob.getXRot();
+        }
+
+        @Override
+        public void setPitch(float rotation) {
+            nmsMob.setXRot(normalizeRotation(rotation));
+        }
+
+        @Override
+        public float getMaxUpStep() {
+            return nmsMob.maxUpStep;
+        }
+
+        @Override
+        public void setMaxUpStep(float maxUpStep) {
+            nmsMob.maxUpStep = maxUpStep;
         }
     }
 

--- a/1_18_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R2.java
+++ b/1_18_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R2.java
@@ -940,7 +940,7 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
 
         @Override
         public void setBodyRotation(float rotation) {
-            nmsMob.yBodyRot = rotation > 360 ? (rotation - (float) (360 * Math.floor(rotation / 360))) : rotation;
+            nmsMob.yBodyRot = normalizeRotation(rotation);
         }
 
         @Override
@@ -950,7 +950,7 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
 
         @Override
         public void setHeadRotation(float rotation) {
-            nmsMob.yHeadRot = rotation > 360 ? (rotation - (float) (360 * Math.floor(rotation / 360))) : rotation;
+            nmsMob.yHeadRot = normalizeRotation(rotation);
         }
 
         @Override
@@ -1077,6 +1077,36 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
         @Override
         public boolean isPushableBy(@Nullable Entity entity) {
             return EntitySelector.pushableBy(toNMS(entity)).test(toNMS(entity));
+        }
+
+        @Override
+        public float getYaw() {
+            return nmsMob.getYRot();
+        }
+
+        @Override
+        public void setYaw(float rotation) {
+            nmsMob.setYRot(normalizeRotation(rotation));
+        }
+
+        @Override
+        public float getPitch() {
+            return nmsMob.getXRot();
+        }
+
+        @Override
+        public void setPitch(float rotation) {
+            nmsMob.setXRot(normalizeRotation(rotation));
+        }
+
+        @Override
+        public float getMaxUpStep() {
+            return nmsMob.maxUpStep;
+        }
+
+        @Override
+        public void setMaxUpStep(float maxUpStep) {
+            nmsMob.maxUpStep = maxUpStep;
         }
     }
 

--- a/1_18_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R2.java
+++ b/1_18_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R2.java
@@ -1659,7 +1659,9 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
         for (Class<?> c : nms) {
 
             Class<? extends Entity> bukkit = fromNMS((Class<? extends net.minecraft.world.entity.Entity>) c, Entity.class);
-            for (EntityType t : EntityType.values()) if (t.getEntityClass().isAssignableFrom(bukkit)) types.add(t);
+            for (EntityType t : EntityType.values()) {
+                if (t.getEntityClass() != null && t.getEntityClass().isAssignableFrom(bukkit)) types.add(t);
+            }
         }
         return types.toArray(new EntityType[0]);
     }

--- a/1_19_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_19_R1.java
+++ b/1_19_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_19_R1.java
@@ -949,7 +949,7 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
 
         @Override
         public void setBodyRotation(float rotation) {
-            nmsMob.yBodyRot = rotation > 360 ? (rotation - (float) (360 * Math.floor(rotation / 360))) : rotation;
+            nmsMob.yBodyRot = normalizeRotation(rotation);
         }
 
         @Override
@@ -959,7 +959,7 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
 
         @Override
         public void setHeadRotation(float rotation) {
-            nmsMob.yHeadRot = rotation > 360 ? (rotation - (float) (360 * Math.floor(rotation / 360))) : rotation;
+            nmsMob.yHeadRot = normalizeRotation(rotation);
         }
 
         @Override
@@ -1086,6 +1086,36 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
         @Override
         public boolean isPushableBy(@Nullable Entity entity) {
             return EntitySelector.pushableBy(toNMS(entity)).test(toNMS(entity));
+        }
+
+        @Override
+        public float getYaw() {
+            return nmsMob.getYRot();
+        }
+
+        @Override
+        public void setYaw(float rotation) {
+            nmsMob.setYRot(normalizeRotation(rotation));
+        }
+
+        @Override
+        public float getPitch() {
+            return nmsMob.getXRot();
+        }
+
+        @Override
+        public void setPitch(float rotation) {
+            nmsMob.setXRot(normalizeRotation(rotation));
+        }
+
+        @Override
+        public float getMaxUpStep() {
+            return nmsMob.maxUpStep;
+        }
+
+        @Override
+        public void setMaxUpStep(float maxUpStep) {
+            nmsMob.maxUpStep = maxUpStep;
         }
     }
 

--- a/1_19_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_19_R1.java
+++ b/1_19_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_19_R1.java
@@ -1685,7 +1685,9 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
         for (Class<?> c : nms) {
 
             Class<? extends Entity> bukkit = fromNMS((Class<? extends net.minecraft.world.entity.Entity>) c, Entity.class);
-            for (EntityType t : EntityType.values()) if (t.getEntityClass().isAssignableFrom(bukkit)) types.add(t);
+            for (EntityType t : EntityType.values()) {
+                if (t.getEntityClass() != null && t.getEntityClass().isAssignableFrom(bukkit)) types.add(t);
+            }
         }
         return types.toArray(new EntityType[0]);
     }

--- a/base/src/main/java/me/gamercoder215/mobchip/EntityBody.java
+++ b/base/src/main/java/me/gamercoder215/mobchip/EntityBody.java
@@ -247,6 +247,10 @@ public interface EntityBody {
      */
     boolean isMoving();
 
+    default float normalizeRotation(float rotation) {
+        return rotation > 360 ? (rotation - (float) (360 * Math.floor(rotation / 360))) : rotation;
+    }
+
     /**
      * Fetches the Mob's current body rotation (between 0.0F and 360.0F)
      * @return Current Body Rotation
@@ -274,6 +278,34 @@ public interface EntityBody {
      * @param rotation Head Rotation to set
      */
     void setHeadRotation(float rotation);
+
+    /**
+     * Fetches the Mob's current yaw (between 0.0F and 360.0F)
+     * @return Current Yaw
+     */
+    float getYaw();
+
+    /**
+     * Sets the Mob's current yaw.
+     * <br><br>
+     * If the rotation is not between 0.0F and 360.0F, it will be wrapped to be between 0.0F and 360.0F (e.g. 480.0F = 120.0F).
+     * @param rotation Yaw to set
+     */
+    void setYaw(float rotation);
+
+    /**
+     * Fetches the Mob's current pitch (between 0.0F and 360.0F)
+     * @return Current Pitch
+     */
+    float getPitch();
+
+    /**
+     * Sets the Mob's current pitch.
+     * <br><br>
+     * If the rotation is not between 0.0F and 360.0F, it will be wrapped to be between 0.0F and 360.0F (e.g. 480.0F = 120.0F).
+     * @param rotation Pitch to set
+     */
+    void setPitch(float rotation);
 
     /**
      * Fetches a set of all entities that this Mob will not collide with.
@@ -407,4 +439,15 @@ public interface EntityBody {
      */
     boolean isPushableBy(@Nullable Entity entity);
 
+    /**
+     * Fetches the maximum block height this entity can walk up without jumping.
+     * @return Maximum step height
+     */
+    float getMaxUpStep();
+
+    /**
+     * Sets the maximum block height this entity can walk up without jumping.
+     * @param maxUpStep Maximum step height
+     */
+    void setMaxUpStep(float maxUpStep);
 }


### PR DESCRIPTION
## Info
This PR adds some new methods and fixes a bug.

## Details
I've added getters and setters for three more properties, yaw, pitch, and step height. Yaw was sort of available with `setBodyRotation` and `setHeadRotation` but base entity yaw is treated differently. Pitch and step height are new additions, all added under EntityBody because that seemed like a good place.

Also, this PR adds a null check to the `getEntityTypes` method, because `EntityType.UNKNOWN` has a null class.

Lastly, I'm wondering about having a method that calls `Entity#move(MoverType, Vec3)` because it's useful for causing smooth entity movement. It seems like using `MoverType.SELF` would work for most cases, so I don't think we'd necessarily need a wrapper for `MoverType`, but I'd like to hear what you think about this? (The difference between `Entity#move` and the existing `moveTo` is that `Entity#move` operates at a lower level, and changes the location instantly instead of using the entity's AI to do it.)

## Tested Environments

### OS
OS: Debian 11

### Java / Minecraft

#### MC Builds
- [ ] Tested on Latest Spigot Version
- [X] Tested on Latest Paper / Purpur Version

#### JDK Builds
Tested on:
- [ ] JDK Version 8/11
- [X] JDK Version 17/18

## Demonstration
Pitch modification test
![eSYUOxFp9H](https://user-images.githubusercontent.com/17661376/192122597-4d8a17f7-29a5-4590-bf0f-bc2712e12653.gif)
