### PR TITLE
Fix custom goal not recognized; remove duplicate entity classes

### DIFF
--- a/1_13_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R1.java
+++ b/1_13_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R1.java
@@ -1581,6 +1581,10 @@ public final class ChipUtil1_13_R1 implements ChipUtil {
     private static Location fromNMS(BlockPosition p, World w) { return new Location(w, p.getX(), p.getY(), p.getZ()); }
 
     private Pathfinder fromNMS(PathfinderGoal g) {
+        if (g instanceof CustomGoal1_13_R1) {
+            return ((CustomGoal1_13_R1) g).getPathfinder();
+        }
+
         Mob m = getEntity(g);
         String name = g.getClass().getSimpleName();
 
@@ -1637,12 +1641,6 @@ public final class ChipUtil1_13_R1 implements ChipUtil {
                 case "OwnerHurtByTarget": return new PathfinderOwnerHurtByTarget((Tameable) m);
                 case "OwnerHurtTarget": return new PathfinderOwnerHurtTarget((Tameable) m);
                 case "RandomTargetNonTamed": return new PathfinderWildTarget<>((Tameable) m, fromNMS(getObject(g, "a", Class.class), LivingEntity.class), getBoolean(g, "f"));
-
-                // Custom
-                case "CustomGoal1_13_R1": {
-                    CustomGoal1_13_R1 goal = (CustomGoal1_13_R1) g;
-                    return goal.getPathfinder();
-                }
 
                 default: return custom(g);
             }

--- a/1_13_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R2.java
+++ b/1_13_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R2.java
@@ -1593,6 +1593,10 @@ public class ChipUtil1_13_R2 implements ChipUtil {
     private static Location fromNMS(BlockPosition p, World w) { return new Location(w, p.getX(), p.getY(), p.getZ()); }
 
     private Pathfinder fromNMS(PathfinderGoal g) {
+        if (g instanceof CustomGoal1_13_R2) {
+            return ((CustomGoal1_13_R2) g).getPathfinder();
+        }
+
         Mob m = getEntity(g);
         String name = g.getClass().getSimpleName();
 
@@ -1649,12 +1653,6 @@ public class ChipUtil1_13_R2 implements ChipUtil {
                 case "OwnerHurtByTarget": return new PathfinderOwnerHurtByTarget((Tameable) m);
                 case "OwnerHurtTarget": return new PathfinderOwnerHurtTarget((Tameable) m);
                 case "RandomTargetNonTamed": return new PathfinderWildTarget<>((Tameable) m, fromNMS(getObject(g, "a", Class.class), LivingEntity.class), getBoolean(g, "f"));
-
-                // Custom
-                case "CustomGoal1_13_R2": {
-                    CustomGoal1_13_R2 goal = (CustomGoal1_13_R2) g;
-                    return goal.getPathfinder();
-                }
 
                 default: return custom(g);
             }

--- a/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_14_R1.java
+++ b/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_14_R1.java
@@ -1919,6 +1919,10 @@ public class ChipUtil1_14_R1 implements ChipUtil {
     private static Location fromNMS(BlockPosition p, World w) { return new Location(w, p.getX(), p.getY(), p.getZ()); }
 
     private Pathfinder fromNMS(PathfinderGoal g) {
+        if (g instanceof CustomGoal1_14_R1) {
+            return ((CustomGoal1_14_R1) g).getPathfinder();
+        }
+
         Mob m = getEntity(g);
         String name = g.getClass().getSimpleName();
 
@@ -1987,12 +1991,6 @@ public class ChipUtil1_14_R1 implements ChipUtil {
                 case "OwnerHurtByTarget": return new PathfinderOwnerHurtByTarget((Tameable) m);
                 case "OwnerHurtTarget": return new PathfinderOwnerHurtTarget((Tameable) m);
                 case "RandomTargetNonTamed": return new PathfinderWildTarget<>((Tameable) m, fromNMS(getObject(g, "a", Class.class), LivingEntity.class), getBoolean(g, "f"), l -> getObject(g, "d", PathfinderTargetCondition.class).a(null, toNMS(l)));
-
-                // Custom
-                case "CustomGoal1_14_R1": {
-                    CustomGoal1_14_R1 goal = (CustomGoal1_14_R1) g;
-                    return goal.getPathfinder();
-                }
 
                 default: return custom(g);
             }

--- a/1_15_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_15_R1.java
+++ b/1_15_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_15_R1.java
@@ -1913,6 +1913,10 @@ public class ChipUtil1_15_R1 implements ChipUtil {
     private static Location fromNMS(BlockPosition p, World w) { return new Location(w, p.getX(), p.getY(), p.getZ()); }
 
     private Pathfinder fromNMS(PathfinderGoal g) {
+        if (g instanceof CustomGoal1_15_R1) {
+            return ((CustomGoal1_15_R1) g).getPathfinder();
+        }
+
         Mob m = getEntity(g);
         String name = g.getClass().getSimpleName();
 
@@ -1982,12 +1986,6 @@ public class ChipUtil1_15_R1 implements ChipUtil {
                 case "OwnerHurtByTarget": return new PathfinderOwnerHurtByTarget((Tameable) m);
                 case "OwnerHurtTarget": return new PathfinderOwnerHurtTarget((Tameable) m);
                 case "RandomTargetNonTamed": return new PathfinderWildTarget<>((Tameable) m, fromNMS(getObject(g, "a", Class.class), LivingEntity.class), getBoolean(g, "f"), l -> getObject(g, "d", PathfinderTargetCondition.class).a(null, toNMS(l)));
-
-                // Custom
-                case "CustomGoal1_15_R1": {
-                    CustomGoal1_15_R1 goal = (CustomGoal1_15_R1) g;
-                    return goal.getPathfinder();
-                }
 
                 default: return custom(g);
             }

--- a/1_16_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R1.java
+++ b/1_16_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R1.java
@@ -1947,6 +1947,10 @@ public class ChipUtil1_16_R1 implements ChipUtil {
     private static Location fromNMS(BlockPosition p, World w) { return new Location(w, p.getX(), p.getY(), p.getZ()); }
 
     private Pathfinder fromNMS(PathfinderGoal g) {
+        if (g instanceof CustomGoal1_16_R1) {
+            return ((CustomGoal1_16_R1) g).getPathfinder();
+        }
+
         Mob m = getEntity(g);
         String name = g.getClass().getSimpleName();
 
@@ -2016,12 +2020,6 @@ public class ChipUtil1_16_R1 implements ChipUtil {
                 case "OwnerHurtByTarget": return new PathfinderOwnerHurtByTarget((Tameable) m);
                 case "OwnerHurtTarget": return new PathfinderOwnerHurtTarget((Tameable) m);
                 case "RandomTargetNonTamed": return new PathfinderWildTarget<>((Tameable) m, fromNMS(getObject(g, "a", Class.class), LivingEntity.class), getBoolean(g, "f"), l -> getObject(g, "d", PathfinderTargetCondition.class).a(null, toNMS(l)));
-
-                // Custom
-                case "CustomGoal1_16_R1": {
-                    CustomGoal1_16_R1 goal = (CustomGoal1_16_R1) g;
-                    return goal.getPathfinder();
-                }
 
                 default: return custom(g);
             }
@@ -2526,6 +2524,6 @@ public class ChipUtil1_16_R1 implements ChipUtil {
         return new EntityNBT1_16_R1(m);
     }
 
-    
-    
+
+
 }

--- a/1_16_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R2.java
+++ b/1_16_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R2.java
@@ -1944,6 +1944,10 @@ public class ChipUtil1_16_R2 implements ChipUtil {
     private static Location fromNMS(BlockPosition p, World w) { return new Location(w, p.getX(), p.getY(), p.getZ()); }
 
     private Pathfinder fromNMS(PathfinderGoal g) {
+        if (g instanceof CustomGoal1_16_R2) {
+            return ((CustomGoal1_16_R2) g).getPathfinder();
+        }
+
         Mob m = getEntity(g);
         String name = g.getClass().getSimpleName();
 
@@ -2013,12 +2017,6 @@ public class ChipUtil1_16_R2 implements ChipUtil {
                 case "OwnerHurtByTarget": return new PathfinderOwnerHurtByTarget((Tameable) m);
                 case "OwnerHurtTarget": return new PathfinderOwnerHurtTarget((Tameable) m);
                 case "RandomTargetNonTamed": return new PathfinderWildTarget<>((Tameable) m, fromNMS(getObject(g, "a", Class.class), LivingEntity.class), getBoolean(g, "f"), l -> getObject(g, "d", PathfinderTargetCondition.class).a(null, toNMS(l)));
-
-                // Custom
-                case "CustomGoal1_16_R2": {
-                    CustomGoal1_16_R2 goal = (CustomGoal1_16_R2) g;
-                    return goal.getPathfinder();
-                }
 
                 default: return custom(g);
             }

--- a/1_16_R3/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R3.java
+++ b/1_16_R3/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R3.java
@@ -1673,7 +1673,7 @@ public class ChipUtil1_16_R3 implements ChipUtil {
             if (name.contains("Entity")) name = name.replace("Entity", "");
 
             final Class<? extends Entity> bukkit;
-            
+
             switch (name) {
                 case "": bukkit = Entity.class; break;
                 case "Living": bukkit = LivingEntity.class; break;
@@ -1924,6 +1924,10 @@ public class ChipUtil1_16_R3 implements ChipUtil {
     private static Location fromNMS(BlockPosition p, World w) { return new Location(w, p.getX(), p.getY(), p.getZ()); }
 
     private Pathfinder fromNMS(PathfinderGoal g) {
+        if (g instanceof CustomGoal1_16_R3) {
+            return ((CustomGoal1_16_R3) g).getPathfinder();
+        }
+
         Mob m = getEntity(g);
         String name = g.getClass().getSimpleName();
 
@@ -1993,12 +1997,6 @@ public class ChipUtil1_16_R3 implements ChipUtil {
                 case "OwnerHurtByTarget": return new PathfinderOwnerHurtByTarget((Tameable) m);
                 case "OwnerHurtTarget": return new PathfinderOwnerHurtTarget((Tameable) m);
                 case "RandomTargetNonTamed": return new PathfinderWildTarget<>((Tameable) m, fromNMS(getObject(g, "a", Class.class), LivingEntity.class), getBoolean(g, "f"), l -> getObject(g, "d", PathfinderTargetCondition.class).a(null, toNMS(l)));
-
-                // Custom
-                case "CustomGoal1_16_R3": {
-                    CustomGoal1_16_R3 goal = (CustomGoal1_16_R3) g;
-                    return goal.getPathfinder();
-                }
 
                 default: return custom(g);
             }
@@ -2501,5 +2499,5 @@ public class ChipUtil1_16_R3 implements ChipUtil {
     public EntityNBT getNBTEditor(Mob m) {
         return new EntityNBT1_16_R3(m);
     }
-    
+
 }

--- a/1_17_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_17_R1.java
+++ b/1_17_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_17_R1.java
@@ -185,13 +185,13 @@ public final class ChipUtil1_17_R1 implements ChipUtil {
             .put(Cod.class, EntityCod.class)
             .put(Cow.class, EntityCow.class)
             .put(Creeper.class, EntityCreeper.class)
-            .put(Donkey.class, EntityHorseDonkey.class)
             .put(Dolphin.class, EntityDolphin.class)
+            .put(Donkey.class, EntityHorseDonkey.class)
             .put(Drowned.class, EntityDrowned.class)
-            .put(Endermite.class, EntityEndermite.class)
-            .put(Enderman.class, EntityEnderman.class)
-            .put(EnderDragon.class, EntityEnderDragon.class)
             .put(ElderGuardian.class, EntityGuardianElder.class)
+            .put(EnderDragon.class, EntityEnderDragon.class)
+            .put(Enderman.class, EntityEnderman.class)
+            .put(Endermite.class, EntityEndermite.class)
             .put(Evoker.class, EntityEvoker.class)
             .put(Fox.class, EntityFox.class)
             .put(Ghast.class, EntityGhast.class)
@@ -201,23 +201,22 @@ public final class ChipUtil1_17_R1 implements ChipUtil {
             .put(Guardian.class, EntityGuardian.class)
             .put(Hoglin.class, EntityHoglin.class)
             .put(Horse.class, EntityHorse.class)
-            .put(Husk.class, EntityZombieHusk.class)
             .put(HumanEntity.class, EntityHuman.class)
+            .put(Husk.class, EntityZombieHusk.class)
             .put(IronGolem.class, EntityIronGolem.class)
             .put(Llama.class, EntityLlama.class)
             .put(MagmaCube.class, EntityMagmaCube.class)
-            .put(MushroomCow.class, EntityMushroomCow.class)
             .put(Mule.class, EntityHorseMule.class)
+            .put(MushroomCow.class, EntityMushroomCow.class)
             .put(Ocelot.class, EntityOcelot.class)
-            .put(Parrot.class, EntityParrot.class)
             .put(Panda.class, EntityPanda.class)
-            .put(PolarBear.class, EntityPolarBear.class)
+            .put(Parrot.class, EntityParrot.class)
             .put(Phantom.class, EntityPhantom.class)
             .put(Pig.class, EntityPig.class)
+            .put(PigZombie.class, EntityPigZombie.class)
             .put(Piglin.class, EntityPiglin.class)
             .put(PiglinBrute.class, EntityPiglinBrute.class)
             .put(Pillager.class, EntityPillager.class)
-            .put(PigZombie.class, EntityPigZombie.class)
             .put(Player.class, EntityPlayer.class)
             .put(PolarBear.class, EntityPolarBear.class)
             .put(PufferFish.class, EntityPufferFish.class)
@@ -225,22 +224,20 @@ public final class ChipUtil1_17_R1 implements ChipUtil {
             .put(Raider.class, EntityRaider.class)
             .put(Ravager.class, EntityRavager.class)
             .put(Salmon.class, EntitySalmon.class)
+            .put(Sheep.class, EntitySheep.class)
             .put(Shulker.class, EntityShulker.class)
             .put(Silverfish.class, EntitySilverfish.class)
-            .put(Sheep.class, EntitySheep.class)
             .put(Skeleton.class, EntitySkeleton.class)
             .put(SkeletonHorse.class, EntityHorseSkeleton.class)
             .put(Slime.class, EntitySlime.class)
-            .put(Shulker.class, EntityShulker.class)
             .put(Snowman.class, EntitySnowman.class)
             .put(Spider.class, EntitySpider.class)
             .put(Squid.class, EntitySquid.class)
             .put(Stray.class, EntitySkeletonStray.class)
             .put(Strider.class, EntityStrider.class)
-            .put(TropicalFish.class, EntityTropicalFish.class)
-            .put(Turtle.class, EntityTurtle.class)
             .put(TraderLlama.class, EntityLlamaTrader.class)
             .put(TropicalFish.class, EntityTropicalFish.class)
+            .put(Turtle.class, EntityTurtle.class)
             .put(Vex.class, EntityVex.class)
             .put(Villager.class, EntityVillager.class)
             .put(Vindicator.class, EntityVindicator.class)
@@ -478,7 +475,7 @@ public final class ChipUtil1_17_R1 implements ChipUtil {
                 PathfinderWildTarget p = (PathfinderWildTarget) b;
                 yield new PathfinderGoalRandomTargetNonTamed<>((EntityTameableAnimal) m, toNMS(p.getFilter()), p.mustSee(), l -> p.getCondition().test(fromNMS(l)));
             }
-            
+
             default -> {
                 if (b instanceof CustomPathfinder p) yield custom(p);
                 else yield null;
@@ -1970,6 +1967,10 @@ public final class ChipUtil1_17_R1 implements ChipUtil {
     private static Location fromNMS(BlockPosition p, World w) { return new Location(w, p.getX(), p.getY(), p.getZ()); }
 
     private Pathfinder fromNMS(PathfinderGoal g) {
+        if (g instanceof CustomGoal1_17_R1 custom) {
+            return custom.getPathfinder();
+        }
+
         Mob m = getEntity(g);
         String name = g.getClass().getSimpleName();
 
@@ -2040,12 +2041,6 @@ public final class ChipUtil1_17_R1 implements ChipUtil {
                 case "OwnerHurtByTarget" -> new PathfinderOwnerHurtByTarget((Tameable) m);
                 case "OwnerHurtTarget" -> new PathfinderOwnerHurtTarget((Tameable) m);
                 case "RandomTargetNonTamed" -> new PathfinderWildTarget<>((Tameable) m, fromNMS(getObject(g, "a", Class.class), LivingEntity.class), getBoolean(g, "f"), l -> getObject(g, "d", PathfinderTargetCondition.class).a(null, toNMS(l)));
-
-                // Custom
-                case "CustomGoal1_17_R1" -> {
-                    CustomGoal1_17_R1 goal = (CustomGoal1_17_R1) g;
-                    yield goal.getPathfinder();
-                }
 
                 default -> custom(g);
             };

--- a/1_18_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R1.java
+++ b/1_18_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R1.java
@@ -199,13 +199,13 @@ public final class ChipUtil1_18_R1 implements ChipUtil {
             .put(Cod.class, net.minecraft.world.entity.animal.Cod.class)
             .put(Cow.class, net.minecraft.world.entity.animal.Cow.class)
             .put(Creeper.class, net.minecraft.world.entity.monster.Creeper.class)
-            .put(Donkey.class, net.minecraft.world.entity.animal.horse.Donkey.class)
             .put(Dolphin.class, net.minecraft.world.entity.animal.Dolphin.class)
+            .put(Donkey.class, net.minecraft.world.entity.animal.horse.Donkey.class)
             .put(Drowned.class, net.minecraft.world.entity.monster.Drowned.class)
-            .put(Endermite.class, net.minecraft.world.entity.monster.Endermite.class)
-            .put(Enderman.class, EnderMan.class)
-            .put(EnderDragon.class, net.minecraft.world.entity.boss.enderdragon.EnderDragon.class)
             .put(ElderGuardian.class, net.minecraft.world.entity.monster.ElderGuardian.class)
+            .put(EnderDragon.class, net.minecraft.world.entity.boss.enderdragon.EnderDragon.class)
+            .put(Enderman.class, EnderMan.class)
+            .put(Endermite.class, net.minecraft.world.entity.monster.Endermite.class)
             .put(Evoker.class, net.minecraft.world.entity.monster.Evoker.class)
             .put(Fox.class, net.minecraft.world.entity.animal.Fox.class)
             .put(Ghast.class, net.minecraft.world.entity.monster.Ghast.class)
@@ -215,23 +215,22 @@ public final class ChipUtil1_18_R1 implements ChipUtil {
             .put(Guardian.class, net.minecraft.world.entity.monster.Guardian.class)
             .put(Hoglin.class, net.minecraft.world.entity.monster.hoglin.Hoglin.class)
             .put(Horse.class, net.minecraft.world.entity.animal.horse.Horse.class)
-            .put(Husk.class, net.minecraft.world.entity.monster.Husk.class)
             .put(HumanEntity.class, net.minecraft.world.entity.player.Player.class)
+            .put(Husk.class, net.minecraft.world.entity.monster.Husk.class)
             .put(IronGolem.class, net.minecraft.world.entity.animal.IronGolem.class)
             .put(Llama.class, net.minecraft.world.entity.animal.horse.Llama.class)
             .put(MagmaCube.class, net.minecraft.world.entity.monster.MagmaCube.class)
-            .put(MushroomCow.class, net.minecraft.world.entity.animal.MushroomCow.class)
             .put(Mule.class, net.minecraft.world.entity.animal.horse.Mule.class)
+            .put(MushroomCow.class, net.minecraft.world.entity.animal.MushroomCow.class)
             .put(Ocelot.class, net.minecraft.world.entity.animal.Ocelot.class)
-            .put(Parrot.class, net.minecraft.world.entity.animal.Parrot.class)
             .put(Panda.class, net.minecraft.world.entity.animal.Panda.class)
-            .put(PolarBear.class, net.minecraft.world.entity.animal.PolarBear.class)
+            .put(Parrot.class, net.minecraft.world.entity.animal.Parrot.class)
             .put(Phantom.class, net.minecraft.world.entity.monster.Phantom.class)
             .put(Pig.class, net.minecraft.world.entity.animal.Pig.class)
+            .put(PigZombie.class, ZombifiedPiglin.class)
             .put(Piglin.class, net.minecraft.world.entity.monster.piglin.Piglin.class)
             .put(PiglinBrute.class, net.minecraft.world.entity.monster.piglin.PiglinBrute.class)
             .put(Pillager.class, net.minecraft.world.entity.monster.Pillager.class)
-            .put(PigZombie.class, ZombifiedPiglin.class)
             .put(Player.class, ServerPlayer.class)
             .put(PolarBear.class, net.minecraft.world.entity.animal.PolarBear.class)
             .put(PufferFish.class, Pufferfish.class)
@@ -239,22 +238,20 @@ public final class ChipUtil1_18_R1 implements ChipUtil {
             .put(Raider.class, net.minecraft.world.entity.raid.Raider.class)
             .put(Ravager.class, net.minecraft.world.entity.monster.Ravager.class)
             .put(Salmon.class, net.minecraft.world.entity.animal.Salmon.class)
+            .put(Sheep.class, net.minecraft.world.entity.animal.Sheep.class)
             .put(Shulker.class, net.minecraft.world.entity.monster.Shulker.class)
             .put(Silverfish.class, net.minecraft.world.entity.monster.Silverfish.class)
-            .put(Sheep.class, net.minecraft.world.entity.animal.Sheep.class)
             .put(Skeleton.class, net.minecraft.world.entity.monster.Skeleton.class)
             .put(SkeletonHorse.class, net.minecraft.world.entity.animal.horse.SkeletonHorse.class)
             .put(Slime.class, net.minecraft.world.entity.monster.Slime.class)
-            .put(Shulker.class, net.minecraft.world.entity.monster.Shulker.class)
             .put(Snowman.class, SnowGolem.class)
             .put(Spider.class, net.minecraft.world.entity.monster.Spider.class)
             .put(Squid.class, net.minecraft.world.entity.animal.Squid.class)
             .put(Stray.class, net.minecraft.world.entity.monster.Stray.class)
             .put(Strider.class, net.minecraft.world.entity.monster.Strider.class)
-            .put(TropicalFish.class, net.minecraft.world.entity.animal.TropicalFish.class)
-            .put(Turtle.class, net.minecraft.world.entity.animal.Turtle.class)
             .put(TraderLlama.class, net.minecraft.world.entity.animal.horse.TraderLlama.class)
             .put(TropicalFish.class, net.minecraft.world.entity.animal.TropicalFish.class)
+            .put(Turtle.class, net.minecraft.world.entity.animal.Turtle.class)
             .put(Vex.class, net.minecraft.world.entity.monster.Vex.class)
             .put(Villager.class, net.minecraft.world.entity.npc.Villager.class)
             .put(Vindicator.class, net.minecraft.world.entity.monster.Vindicator.class)
@@ -1991,6 +1988,9 @@ public final class ChipUtil1_18_R1 implements ChipUtil {
     private static Location fromNMS(BlockPos p, World w) { return new Location(w, p.getX(), p.getY(), p.getZ()); }
 
     private Pathfinder fromNMS(Goal g) {
+        if (g instanceof CustomGoal1_18_R1 custom) {
+            return custom.getPathfinder();
+        }
         Mob m = getEntity(g);
         String name = g.getClass().getSimpleName();
 
@@ -2061,12 +2061,6 @@ public final class ChipUtil1_18_R1 implements ChipUtil {
                 case "OwnerHurtByTarget" -> new PathfinderOwnerHurtByTarget((Tameable) m);
                 case "OwnerHurtTarget" -> new PathfinderOwnerHurtTarget((Tameable) m);
                 case "RandomTargetNonTamed" -> new PathfinderWildTarget<>((Tameable) m, fromNMS(getObject(g, "a", Class.class), LivingEntity.class), getBoolean(g, "f"), l -> getObject(g, "d", TargetingConditions.class).test(null, toNMS(l)));
-
-                // Custom
-                case "CustomGoal1_18_R1" -> {
-                    CustomGoal1_18_R1 goal = (CustomGoal1_18_R1) g;
-                    yield goal.getPathfinder();
-                }
 
                 default -> custom(g);
             };

--- a/1_18_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R2.java
+++ b/1_18_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R2.java
@@ -199,13 +199,13 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
             .put(Cod.class, net.minecraft.world.entity.animal.Cod.class)
             .put(Cow.class, net.minecraft.world.entity.animal.Cow.class)
             .put(Creeper.class, net.minecraft.world.entity.monster.Creeper.class)
-            .put(Donkey.class, net.minecraft.world.entity.animal.horse.Donkey.class)
             .put(Dolphin.class, net.minecraft.world.entity.animal.Dolphin.class)
+            .put(Donkey.class, net.minecraft.world.entity.animal.horse.Donkey.class)
             .put(Drowned.class, net.minecraft.world.entity.monster.Drowned.class)
-            .put(Endermite.class, net.minecraft.world.entity.monster.Endermite.class)
-            .put(Enderman.class, EnderMan.class)
-            .put(EnderDragon.class, net.minecraft.world.entity.boss.enderdragon.EnderDragon.class)
             .put(ElderGuardian.class, net.minecraft.world.entity.monster.ElderGuardian.class)
+            .put(EnderDragon.class, net.minecraft.world.entity.boss.enderdragon.EnderDragon.class)
+            .put(Enderman.class, EnderMan.class)
+            .put(Endermite.class, net.minecraft.world.entity.monster.Endermite.class)
             .put(Evoker.class, net.minecraft.world.entity.monster.Evoker.class)
             .put(Fox.class, net.minecraft.world.entity.animal.Fox.class)
             .put(Ghast.class, net.minecraft.world.entity.monster.Ghast.class)
@@ -215,23 +215,22 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
             .put(Guardian.class, net.minecraft.world.entity.monster.Guardian.class)
             .put(Hoglin.class, net.minecraft.world.entity.monster.hoglin.Hoglin.class)
             .put(Horse.class, net.minecraft.world.entity.animal.horse.Horse.class)
-            .put(Husk.class, net.minecraft.world.entity.monster.Husk.class)
             .put(HumanEntity.class, net.minecraft.world.entity.player.Player.class)
+            .put(Husk.class, net.minecraft.world.entity.monster.Husk.class)
             .put(IronGolem.class, net.minecraft.world.entity.animal.IronGolem.class)
             .put(Llama.class, net.minecraft.world.entity.animal.horse.Llama.class)
             .put(MagmaCube.class, net.minecraft.world.entity.monster.MagmaCube.class)
-            .put(MushroomCow.class, net.minecraft.world.entity.animal.MushroomCow.class)
             .put(Mule.class, net.minecraft.world.entity.animal.horse.Mule.class)
+            .put(MushroomCow.class, net.minecraft.world.entity.animal.MushroomCow.class)
             .put(Ocelot.class, net.minecraft.world.entity.animal.Ocelot.class)
-            .put(Parrot.class, net.minecraft.world.entity.animal.Parrot.class)
             .put(Panda.class, net.minecraft.world.entity.animal.Panda.class)
-            .put(PolarBear.class, net.minecraft.world.entity.animal.PolarBear.class)
+            .put(Parrot.class, net.minecraft.world.entity.animal.Parrot.class)
             .put(Phantom.class, net.minecraft.world.entity.monster.Phantom.class)
             .put(Pig.class, net.minecraft.world.entity.animal.Pig.class)
+            .put(PigZombie.class, ZombifiedPiglin.class)
             .put(Piglin.class, net.minecraft.world.entity.monster.piglin.Piglin.class)
             .put(PiglinBrute.class, net.minecraft.world.entity.monster.piglin.PiglinBrute.class)
             .put(Pillager.class, net.minecraft.world.entity.monster.Pillager.class)
-            .put(PigZombie.class, ZombifiedPiglin.class)
             .put(Player.class, ServerPlayer.class)
             .put(PolarBear.class, net.minecraft.world.entity.animal.PolarBear.class)
             .put(PufferFish.class, Pufferfish.class)
@@ -239,22 +238,20 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
             .put(Raider.class, net.minecraft.world.entity.raid.Raider.class)
             .put(Ravager.class, net.minecraft.world.entity.monster.Ravager.class)
             .put(Salmon.class, net.minecraft.world.entity.animal.Salmon.class)
+            .put(Sheep.class, net.minecraft.world.entity.animal.Sheep.class)
             .put(Shulker.class, net.minecraft.world.entity.monster.Shulker.class)
             .put(Silverfish.class, net.minecraft.world.entity.monster.Silverfish.class)
-            .put(Sheep.class, net.minecraft.world.entity.animal.Sheep.class)
             .put(Skeleton.class, net.minecraft.world.entity.monster.Skeleton.class)
             .put(SkeletonHorse.class, net.minecraft.world.entity.animal.horse.SkeletonHorse.class)
             .put(Slime.class, net.minecraft.world.entity.monster.Slime.class)
-            .put(Shulker.class, net.minecraft.world.entity.monster.Shulker.class)
             .put(Snowman.class, SnowGolem.class)
             .put(Spider.class, net.minecraft.world.entity.monster.Spider.class)
             .put(Squid.class, net.minecraft.world.entity.animal.Squid.class)
             .put(Stray.class, net.minecraft.world.entity.monster.Stray.class)
             .put(Strider.class, net.minecraft.world.entity.monster.Strider.class)
-            .put(TropicalFish.class, net.minecraft.world.entity.animal.TropicalFish.class)
-            .put(Turtle.class, net.minecraft.world.entity.animal.Turtle.class)
             .put(TraderLlama.class, net.minecraft.world.entity.animal.horse.TraderLlama.class)
             .put(TropicalFish.class, net.minecraft.world.entity.animal.TropicalFish.class)
+            .put(Turtle.class, net.minecraft.world.entity.animal.Turtle.class)
             .put(Vex.class, net.minecraft.world.entity.monster.Vex.class)
             .put(Villager.class, net.minecraft.world.entity.npc.Villager.class)
             .put(Vindicator.class, net.minecraft.world.entity.monster.Vindicator.class)
@@ -1243,7 +1240,7 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
         public void setMaxUpStep(float maxUpStep) {
             nmsMob.maxUpStep = maxUpStep;
         }
-        
+
         @Override
         public Position getLastLavaContact() {
             BlockPos p = nmsMob.lastLavaContact;
@@ -1991,6 +1988,10 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
     private static Location fromNMS(BlockPos p, World w) { return new Location(w, p.getX(), p.getY(), p.getZ()); }
 
     private Pathfinder fromNMS(Goal g) {
+        if (g instanceof CustomGoal1_18_R2 custom) {
+            return custom.getPathfinder();
+        }
+
         Mob m = getEntity(g);
         String name = g.getClass().getSimpleName();
 
@@ -2061,12 +2062,6 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
                 case "OwnerHurtByTarget" -> new PathfinderOwnerHurtByTarget((Tameable) m);
                 case "OwnerHurtTarget" -> new PathfinderOwnerHurtTarget((Tameable) m);
                 case "RandomTargetNonTamed" -> new PathfinderWildTarget<>((Tameable) m, fromNMS(getObject(g, "a", Class.class), LivingEntity.class), getBoolean(g, "f"), l -> getObject(g, "d", TargetingConditions.class).test(null, toNMS(l)));
-
-                // Custom
-                case "CustomGoal1_18_R2" -> {
-                    CustomGoal1_18_R2 goal = (CustomGoal1_18_R2) g;
-                    yield goal.getPathfinder();
-                }
 
                 default -> custom(g);
             };
@@ -2232,7 +2227,7 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
     private static net.minecraft.world.entity.ai.gossip.GossipType toNMS(GossipType t) {
         return net.minecraft.world.entity.ai.gossip.GossipType.byId(t.getKey().getKey());
     }
-    
+
     private static GossipType fromNMS(net.minecraft.world.entity.ai.gossip.GossipType t) {
         return GossipType.getByKey(NamespacedKey.minecraft(t.id));
     }

--- a/1_19_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_19_R1.java
+++ b/1_19_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_19_R1.java
@@ -205,13 +205,13 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
             .put(Cod.class, net.minecraft.world.entity.animal.Cod.class)
             .put(Cow.class, net.minecraft.world.entity.animal.Cow.class)
             .put(Creeper.class, net.minecraft.world.entity.monster.Creeper.class)
-            .put(Donkey.class, net.minecraft.world.entity.animal.horse.Donkey.class)
             .put(Dolphin.class, net.minecraft.world.entity.animal.Dolphin.class)
+            .put(Donkey.class, net.minecraft.world.entity.animal.horse.Donkey.class)
             .put(Drowned.class, net.minecraft.world.entity.monster.Drowned.class)
-            .put(Endermite.class, net.minecraft.world.entity.monster.Endermite.class)
-            .put(Enderman.class, EnderMan.class)
-            .put(EnderDragon.class, net.minecraft.world.entity.boss.enderdragon.EnderDragon.class)
             .put(ElderGuardian.class, net.minecraft.world.entity.monster.ElderGuardian.class)
+            .put(EnderDragon.class, net.minecraft.world.entity.boss.enderdragon.EnderDragon.class)
+            .put(Enderman.class, EnderMan.class)
+            .put(Endermite.class, net.minecraft.world.entity.monster.Endermite.class)
             .put(Evoker.class, net.minecraft.world.entity.monster.Evoker.class)
             .put(Fox.class, net.minecraft.world.entity.animal.Fox.class)
             .put(Frog.class, net.minecraft.world.entity.animal.frog.Frog.class)
@@ -222,23 +222,22 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
             .put(Guardian.class, net.minecraft.world.entity.monster.Guardian.class)
             .put(Hoglin.class, net.minecraft.world.entity.monster.hoglin.Hoglin.class)
             .put(Horse.class, net.minecraft.world.entity.animal.horse.Horse.class)
-            .put(Husk.class, net.minecraft.world.entity.monster.Husk.class)
             .put(HumanEntity.class, net.minecraft.world.entity.player.Player.class)
+            .put(Husk.class, net.minecraft.world.entity.monster.Husk.class)
             .put(IronGolem.class, net.minecraft.world.entity.animal.IronGolem.class)
             .put(Llama.class, net.minecraft.world.entity.animal.horse.Llama.class)
             .put(MagmaCube.class, net.minecraft.world.entity.monster.MagmaCube.class)
-            .put(MushroomCow.class, net.minecraft.world.entity.animal.MushroomCow.class)
             .put(Mule.class, net.minecraft.world.entity.animal.horse.Mule.class)
+            .put(MushroomCow.class, net.minecraft.world.entity.animal.MushroomCow.class)
             .put(Ocelot.class, net.minecraft.world.entity.animal.Ocelot.class)
-            .put(Parrot.class, net.minecraft.world.entity.animal.Parrot.class)
             .put(Panda.class, net.minecraft.world.entity.animal.Panda.class)
-            .put(PolarBear.class, net.minecraft.world.entity.animal.PolarBear.class)
+            .put(Parrot.class, net.minecraft.world.entity.animal.Parrot.class)
             .put(Phantom.class, net.minecraft.world.entity.monster.Phantom.class)
             .put(Pig.class, net.minecraft.world.entity.animal.Pig.class)
             .put(Piglin.class, net.minecraft.world.entity.monster.piglin.Piglin.class)
             .put(PiglinBrute.class, net.minecraft.world.entity.monster.piglin.PiglinBrute.class)
-            .put(Pillager.class, net.minecraft.world.entity.monster.Pillager.class)
             .put(PigZombie.class, ZombifiedPiglin.class)
+            .put(Pillager.class, net.minecraft.world.entity.monster.Pillager.class)
             .put(Player.class, ServerPlayer.class)
             .put(PolarBear.class, net.minecraft.world.entity.animal.PolarBear.class)
             .put(PufferFish.class, Pufferfish.class)
@@ -246,23 +245,21 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
             .put(Raider.class, net.minecraft.world.entity.raid.Raider.class)
             .put(Ravager.class, net.minecraft.world.entity.monster.Ravager.class)
             .put(Salmon.class, net.minecraft.world.entity.animal.Salmon.class)
+            .put(Sheep.class, net.minecraft.world.entity.animal.Sheep.class)
             .put(Shulker.class, net.minecraft.world.entity.monster.Shulker.class)
             .put(Silverfish.class, net.minecraft.world.entity.monster.Silverfish.class)
-            .put(Sheep.class, net.minecraft.world.entity.animal.Sheep.class)
             .put(Skeleton.class, net.minecraft.world.entity.monster.Skeleton.class)
             .put(SkeletonHorse.class, net.minecraft.world.entity.animal.horse.SkeletonHorse.class)
             .put(Slime.class, net.minecraft.world.entity.monster.Slime.class)
-            .put(Shulker.class, net.minecraft.world.entity.monster.Shulker.class)
             .put(Snowman.class, SnowGolem.class)
             .put(Spider.class, net.minecraft.world.entity.monster.Spider.class)
             .put(Squid.class, net.minecraft.world.entity.animal.Squid.class)
             .put(Stray.class, net.minecraft.world.entity.monster.Stray.class)
             .put(Strider.class, net.minecraft.world.entity.monster.Strider.class)
             .put(Tadpole.class, net.minecraft.world.entity.animal.frog.Tadpole.class)
-            .put(TropicalFish.class, net.minecraft.world.entity.animal.TropicalFish.class)
-            .put(Turtle.class, net.minecraft.world.entity.animal.Turtle.class)
             .put(TraderLlama.class, net.minecraft.world.entity.animal.horse.TraderLlama.class)
             .put(TropicalFish.class, net.minecraft.world.entity.animal.TropicalFish.class)
+            .put(Turtle.class, net.minecraft.world.entity.animal.Turtle.class)
             .put(Vex.class, net.minecraft.world.entity.monster.Vex.class)
             .put(Villager.class, net.minecraft.world.entity.npc.Villager.class)
             .put(Vindicator.class, net.minecraft.world.entity.monster.Vindicator.class)
@@ -2026,6 +2023,10 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
     private static Location fromNMS(net.minecraft.core.Position p, World w) { return new Location(w, p.x(), p.y(), p.z()); }
 
     private Pathfinder fromNMS(Goal g) {
+        if (g instanceof CustomGoal1_19_R1 custom) {
+            return custom.getPathfinder();
+        }
+
         Mob m = getEntity(g);
         String name = g.getClass().getSimpleName();
 
@@ -2096,12 +2097,6 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
                 case "OwnerHurtByTarget" -> new PathfinderOwnerHurtByTarget((Tameable) m);
                 case "OwnerHurtTarget" -> new PathfinderOwnerHurtTarget((Tameable) m);
                 case "RandomTargetNonTamed" -> new PathfinderWildTarget<>((Tameable) m, fromNMS(getObject(g, "a", Class.class), LivingEntity.class), getBoolean(g, "f"), l -> getObject(g, "d", TargetingConditions.class).test(null, toNMS(l)));
-
-                // Custom
-                case "CustomGoal1_19_R1" -> {
-                    CustomGoal1_19_R1 goal = (CustomGoal1_19_R1) g;
-                    yield goal.getPathfinder();
-                }
 
                 default -> custom(g);
             };


### PR DESCRIPTION
## Info
This PR fixes two issues I found with MobChip 1.6, duplicate entity classes in the BiMap and the check for custom goals being in the wrong place.

## Details
The BiMap `BUKKIT_NMS_MAP` had a couple duplicate entity entries, which caused an error when it was used. I've removed the duplicates and re-sorted the rest.

The check for `CustomGoal`s was previously under an if-block that requires the goal class name to start with `PathfinderGoal`, so it was never called. Instead, I've moved it up to the top of the function because it's the one case where we don't need to use reflection to find the entity referenced in the goal.

## Tested Environments

### OS
OS: Debian 11

### Java / Minecraft

#### MC Builds
- [ ] Tested on Latest Spigot Version
- [X] Tested on Latest Paper / Purpur Version

#### JDK Builds
Tested on:
- [ ] JDK Version 8/11
- [X] JDK Version 17/18

## Demonstration
Resulting error from duplicate keys:
```
[18:16:59 ERROR]: Could not pass event InventoryClickEvent to UltraCosmetics v2.9-RELEASE
java.lang.ExceptionInInitializerError: null
        at java.lang.Class.forName0(Native Method) ~[?:?]
        at java.lang.Class.forName(Class.java:383) ~[?:?]
        at java.lang.Class.forName(Class.java:376) ~[?:?]
        at be.isach.ultracosmetics.shaded.mobchip.abstraction.ChipUtil.getWrapper(ChipUtil.java:167) ~[UltraCosmetics-2.9-RELEASE.jar:?]
        at be.isach.ultracosmetics.shaded.mobchip.bukkit.BukkitBrain.<clinit>(BukkitBrain.java:36) ~[UltraCosmetics-2.9-RELEASE.jar:?]
        at be.isach.ultracosmetics.cosmetics.pets.Pet.onEquip(Pet.java:86) ~[UltraCosmetics-2.9-RELEASE.jar:?]
...
Caused by: java.lang.IllegalArgumentException: Multiple entries with same key: interface org.bukkit.entity.PolarBear=class net.minecraft.world.entity.animal.EntityPolarBear and interface org.bukkit.entity.PolarBear=class net.minecraft.world.entity.animal.EntityPolarBear
        at com.google.common.collect.ImmutableMap.conflictException(ImmutableMap.java:376) ~[guava-31.0.1-jre.jar:?]
        at com.google.common.collect.ImmutableMap.checkNoConflict(ImmutableMap.java:370) ~[guava-31.0.1-jre.jar:?]
        at com.google.common.collect.RegularImmutableMap.checkNoConflictInKeyBucket(RegularImmutableMap.java:153) ~[guava-31.0.1-jre.jar:?]
        at com.google.common.collect.RegularImmutableBiMap.fromEntryArray(RegularImmutableBiMap.java:91) ~[guava-31.0.1-jre.jar:?]
        at com.google.common.collect.ImmutableBiMap$Builder.buildOrThrow(ImmutableBiMap.java:479) ~[guava-31.0.1-jre.jar:?]
        at com.google.common.collect.ImmutableBiMap$Builder.build(ImmutableBiMap.java:439) ~[guava-31.0.1-jre.jar:?]
        at be.isach.ultracosmetics.shaded.mobchip.abstraction.ChipUtil1_19_R1.<clinit>(ChipUtil1_19_R1.java:279) ~[UltraCosmetics-2.9-RELEASE.jar:?]
        ... 36 more
```