### PR TITLE
Fix behaviors failing to construct

### DIFF
--- a/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_14_R1.java
+++ b/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_14_R1.java
@@ -424,7 +424,7 @@ public class ChipUtil1_14_R1 implements ChipUtil {
 
         try {
             Class<?> bClass = Class.forName(packageName + "." + behaviorName);
-            Constructor<?> c = bClass.getConstructor(Arrays.stream(args).map(Object::getClass).toArray(Class[]::new));
+            Constructor<?> c = bClass.getConstructor(ChipUtil.getArgTypes(args));
             Behavior<? super EntityLiving> b = (Behavior<? super EntityLiving>) c.newInstance(args);
             return new BehaviorResult1_14_R1(b, nms);
         } catch (Exception e) {

--- a/1_15_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_15_R1.java
+++ b/1_15_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_15_R1.java
@@ -425,7 +425,7 @@ public class ChipUtil1_15_R1 implements ChipUtil {
 
         try {
             Class<?> bClass = Class.forName(packageName + "." + behaviorName);
-            Constructor<?> c = bClass.getConstructor(Arrays.stream(args).map(Object::getClass).toArray(Class[]::new));
+            Constructor<?> c = bClass.getConstructor(ChipUtil.getArgTypes(args));
             Behavior<? super EntityLiving> b = (Behavior<? super EntityLiving>) c.newInstance(args);
             return new BehaviorResult1_15_R1(b, nms);
         } catch (Exception e) {

--- a/1_16_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R1.java
+++ b/1_16_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R1.java
@@ -465,7 +465,7 @@ public class ChipUtil1_16_R1 implements ChipUtil {
 
         try {
             Class<?> bClass = Class.forName(packageName + "." + behaviorName);
-            Constructor<?> c = bClass.getConstructor(Arrays.stream(args).map(Object::getClass).toArray(Class[]::new));
+            Constructor<?> c = bClass.getConstructor(ChipUtil.getArgTypes(args));
             Behavior<? super EntityLiving> b = (Behavior<? super EntityLiving>) c.newInstance(args);
             return new BehaviorResult1_16_R1(b, nms);
         } catch (Exception e) {

--- a/1_16_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R2.java
+++ b/1_16_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R2.java
@@ -425,7 +425,7 @@ public class ChipUtil1_16_R2 implements ChipUtil {
 
         try {
             Class<?> bClass = Class.forName(packageName + "." + behaviorName);
-            Constructor<?> c = bClass.getConstructor(Arrays.stream(args).map(Object::getClass).toArray(Class[]::new));
+            Constructor<?> c = bClass.getConstructor(ChipUtil.getArgTypes(args));
             Behavior<? super EntityLiving> b = (Behavior<? super EntityLiving>) c.newInstance(args);
             return new BehaviorResult1_16_R2(b, nms);
         } catch (Exception e) {

--- a/1_16_R3/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R3.java
+++ b/1_16_R3/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R3.java
@@ -424,7 +424,7 @@ public class ChipUtil1_16_R3 implements ChipUtil {
 
         try {
             Class<?> bClass = Class.forName(packageName + "." + behaviorName);
-            Constructor<?> c = bClass.getConstructor(Arrays.stream(args).map(Object::getClass).toArray(Class[]::new));
+            Constructor<?> c = bClass.getConstructor(ChipUtil.getArgTypes(args));
             Behavior<? super EntityLiving> b = (Behavior<? super EntityLiving>) c.newInstance(args);
             return new BehaviorResult1_16_R3(b, nms);
         } catch (Exception e) {

--- a/1_17_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_17_R1.java
+++ b/1_17_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_17_R1.java
@@ -530,7 +530,7 @@ public final class ChipUtil1_17_R1 implements ChipUtil {
 
         try {
             Class<?> bClass = Class.forName(packageName + "." + behaviorName);
-            Constructor<?> c = bClass.getConstructor(Arrays.stream(args).map(Object::getClass).toArray(Class[]::new));
+            Constructor<?> c = bClass.getConstructor(ChipUtil.getArgTypes(args));
             Behavior<? super EntityLiving> b = (Behavior<? super EntityLiving>) c.newInstance(args);
             return new BehaviorResult1_17_R1(b, nms);
         } catch (Exception e) {

--- a/1_18_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R1.java
+++ b/1_18_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R1.java
@@ -548,7 +548,7 @@ public final class ChipUtil1_18_R1 implements ChipUtil {
 
         try {
             Class<?> bClass = Class.forName(packageName + "." + behaviorName);
-            Constructor<?> c = bClass.getConstructor(Arrays.stream(args).map(Object::getClass).toArray(Class[]::new));
+            Constructor<?> c = bClass.getConstructor(ChipUtil.getArgTypes(args));
             Behavior<? super net.minecraft.world.entity.LivingEntity> b = (Behavior<? super net.minecraft.world.entity.LivingEntity>) c.newInstance(args);
             return new BehaviorResult1_18_R1(b, nms);
         } catch (Exception e) {

--- a/1_18_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R2.java
+++ b/1_18_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R2.java
@@ -548,7 +548,7 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
 
         try {
             Class<?> bClass = Class.forName(packageName + "." + behaviorName);
-            Constructor<?> c = bClass.getConstructor(Arrays.stream(args).map(Object::getClass).toArray(Class[]::new));
+            Constructor<?> c = bClass.getConstructor(ChipUtil.getArgTypes(args));
             Behavior<? super net.minecraft.world.entity.LivingEntity> b = (Behavior<? super net.minecraft.world.entity.LivingEntity>) c.newInstance(args);
             return new BehaviorResult1_18_R2(b, nms);
         } catch (Exception e) {

--- a/1_19_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_19_R1.java
+++ b/1_19_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_19_R1.java
@@ -560,7 +560,7 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
 
         try {
             Class<?> bClass = Class.forName(packageName + "." + behaviorName);
-            Constructor<?> c = bClass.getConstructor(Arrays.stream(args).map(Object::getClass).toArray(Class[]::new));
+            Constructor<?> c = bClass.getConstructor(ChipUtil.getArgTypes(args));
             Behavior<? super net.minecraft.world.entity.LivingEntity> b = (Behavior<? super net.minecraft.world.entity.LivingEntity>) c.newInstance(args);
             return new BehaviorResult1_19_R1(b, nms);
         } catch (Exception e) {

--- a/abstraction/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil.java
+++ b/abstraction/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil.java
@@ -157,6 +157,24 @@ public interface ChipUtil {
         }
     }
 
+    /**
+     * Finds the classes of an array of objects, using unboxed classes where possible.
+     * (ex. int.class rather than Integer.class)
+     * @param args Objects
+     * @return Classes of objects
+     */
+    static Class<?>[] getArgTypes(Object... args) {
+        Class<?> types[] = new Class<?>[args.length];
+        for (int i = 0; i < args.length; i++) {
+            try {
+                types[i] = (Class<?>) args[i].getClass().getDeclaredField("TYPE").get(null);
+            } catch (ReflectiveOperationException ignored) {
+                types[i] = args[i].getClass();
+            }
+        }
+        return types;
+    }
+
     static String getServerVersion() {
         return Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3].substring(1);
     }


### PR DESCRIPTION
## Info
This PR fixes an error when using `CreatureBehavior#panic` and (probably) similar methods.

## Details
The behavior for `panic` is created using reflection, and arguments are determined by their type in the `runBehavior` function. But due to Java's weirdness about primitives, constructing the panic behavior would fail with an error since it was looking for a constructor with a boxed value (`java.lang.Float`) instead of the unboxed value (just `float`) that the actual constructor uses.

This fixes it using a helper method and some additional reflection, although a solution using a lookup map is also possible. I've placed the helper method in the ChipUtil interface since all ChipUtil implementations use it, but if you have a better place, I'd be happy to move it.

After implementing the changes in this PR, using `CreatureBehavior#panic` no longer throws an error, but the animal still does not panic. I don't think it's related to this issue though.

## Tested Environments

### OS
OS: Debian 11

### Java / Minecraft

#### MC Builds
- [ ] Tested on Latest Spigot Version
- [X] Tested on Latest Paper / Purpur Version

#### JDK Builds
Tested on:
- [ ] JDK Version 8/11
- [X] JDK Version 17/18

## Demonstration
The original error was this:
```
[09:52:37 ERROR]: net.minecraft.world.entity.ai.behavior.AnimalPanic.<init>(java.lang.Float)
[09:52:37 ERROR]: java.base/java.lang.Class.getConstructor0(Class.java:3617)
[09:52:37 ERROR]: java.base/java.lang.Class.getConstructor(Class.java:2303)
[09:52:37 ERROR]: UltraCosmetics-3.0-DEV-b0.jar//be.isach.ultracosmetics.shaded.mobchip.abstraction.ChipUtil1_19_R1.runBehavior(ChipUtil1_19_R1.java:610)
[09:52:37 ERROR]: UltraCosmetics-3.0-DEV-b0.jar//be.isach.ultracosmetics.shaded.mobchip.abstraction.ChipUtil1_19_R1.runBehavior(ChipUtil1_19_R1.java:582)
[09:52:37 ERROR]: UltraCosmetics-3.0-DEV-b0.jar//be.isach.ultracosmetics.shaded.mobchip.bukkit.BukkitEntityBehavior.run(BukkitEntityBehavior.java:29)
[09:52:37 ERROR]: UltraCosmetics-3.0-DEV-b0.jar//be.isach.ultracosmetics.shaded.mobchip.bukkit.BukkitCreatureBehavior.panic(BukkitCreatureBehavior.java:24)
[09:52:37 ERROR]: UltraCosmetics-3.0-DEV-b0.jar//be.isach.ultracosmetics.shaded.mobchip.ai.behavior.CreatureBehavior.panic(CreatureBehavior.java:28)
[09:52:37 ERROR]: UltraCosmetics-3.0-DEV-b0.jar//be.isach.ultracosmetics.cosmetics.gadgets.GadgetExplosiveSheep$SheepColorRunnable.lambda$run$0(GadgetExplosiv
eSheep.java:128)
```
I changed the code so it would print a normal stack trace and got this slightly more helpful message:
```
[11:00:37 WARN]: java.lang.NoSuchMethodException: net.minecraft.world.entity.ai.behavior.AnimalPanic.<init>(java.lang.Float)
[11:00:37 WARN]:        at java.base/java.lang.Class.getConstructor0(Class.java:3617)
[11:00:37 WARN]:        at java.base/java.lang.Class.getConstructor(Class.java:2303)
[11:00:37 WARN]:        at UltraCosmetics-3.0-DEV-b0.jar//be.isach.ultracosmetics.shaded.mobchip.abstraction.ChipUtil1_19_R1.runBehavior(ChipUtil1_19_R1.java:
566)
[11:00:37 WARN]:        at UltraCosmetics-3.0-DEV-b0.jar//be.isach.ultracosmetics.shaded.mobchip.abstraction.ChipUtil1_19_R1.runBehavior(ChipUtil1_19_R1.java:
535)
[11:00:37 WARN]:        at UltraCosmetics-3.0-DEV-b0.jar//be.isach.ultracosmetics.shaded.mobchip.bukkit.BukkitEntityBehavior.run(BukkitEntityBehavior.java:29)
[11:00:37 WARN]:        at UltraCosmetics-3.0-DEV-b0.jar//be.isach.ultracosmetics.shaded.mobchip.bukkit.BukkitCreatureBehavior.panic(BukkitCreatureBehavior.ja
va:24)
[11:00:37 WARN]:        at UltraCosmetics-3.0-DEV-b0.jar//be.isach.ultracosmetics.shaded.mobchip.ai.behavior.CreatureBehavior.panic(CreatureBehavior.java:28)
[11:00:37 WARN]:        at UltraCosmetics-3.0-DEV-b0.jar//be.isach.ultracosmetics.cosmetics.gadgets.GadgetExplosiveSheep$SheepColorRunnable.lambda$run$0(Gadge
tExplosiveSheep.java:128)
```
By the way, is there a reason stack traces are printed manually using this method, instead of just using `e.printStackTrace()`?
```java
Bukkit.getLogger().severe(e.getMessage());
for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
```