### PR TITLE
1_14_R1 targets 1.14.4; fix misc bugs

### DIFF
--- a/1_13_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R1.java
+++ b/1_13_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R1.java
@@ -601,13 +601,18 @@ public final class ChipUtil1_13_R1 implements ChipUtil {
     }
 
     public static Mob getEntity(PathfinderGoal g) {
+        // For no discernible reason, the Mob field in PathfinderGoalDoorInteract
+        // is not final, unlike the mob fields in every other pathfinder.
+        // Since PathfinderGoalDoorInteract and subclasses each only have one mob field,
+        // we can simply ignore the "final" check in this case.
+        boolean ignoreNonFinal = g instanceof PathfinderGoalDoorInteract;
         try {
             Class<? extends PathfinderGoal> clazz = g.getClass();
 
             while (clazz.getSuperclass() != null) {
                 for (Field f : clazz.getDeclaredFields()) {
                     f.setAccessible(true);
-                    if (EntityInsentient.class.isAssignableFrom(f.getType()) && Modifier.isFinal(f.getModifiers())) {
+                    if (EntityInsentient.class.isAssignableFrom(f.getType()) && (ignoreNonFinal || Modifier.isFinal(f.getModifiers()))) {
                         return fromNMS((EntityInsentient) f.get(g));
                     }
                 }
@@ -615,7 +620,6 @@ public final class ChipUtil1_13_R1 implements ChipUtil {
                 if (PathfinderGoal.class.isAssignableFrom(clazz.getSuperclass())) clazz = (Class<? extends PathfinderGoal>) clazz.getSuperclass();
                 else break;
             }
-
             return null;
         } catch (Exception e) {
             Bukkit.getLogger().severe(e.getMessage());
@@ -864,7 +868,7 @@ public final class ChipUtil1_13_R1 implements ChipUtil {
                 case "GotoTarget": return new PathfinderMoveToBlock((Creature) m, l -> fromNMS(getObject(g, "d", BlockPosition.class), m.getWorld()).equals(l), getDouble(g, "a"), getInt(g, "i"), getInt(g, "j"));
                 case "MoveTowardsRestriction": return new PathfinderMoveTowardsRestriction((Creature) m, getDouble(g, "e"));
                 case "MoveTowardsTarget": return new PathfinderMoveTowardsTarget((Creature) m, getDouble(g, "f"), getFloat(g, "g"));
-                case "OcelotAttack": return new PathfinderOcelotAttack((Ocelot) m);
+                case "OcelotAttack": return new PathfinderOcelotAttack(m);
                 case "OfferFlower": return new PathfinderOfferFlower((IronGolem) m);
                 case "Panic": return new PathfinderPanic((Creature) m, getDouble(g, "b"));
                 case "Perch": return new PathfinderRideShoulder((Parrot) m);

--- a/1_13_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R1.java
+++ b/1_13_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R1.java
@@ -1,5 +1,6 @@
 package me.gamercoder215.mobchip.abstraction;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import me.gamercoder215.mobchip.EntityBody;
 import me.gamercoder215.mobchip.abstraction.v1_13_R1.*;
@@ -600,12 +601,27 @@ public final class ChipUtil1_13_R1 implements ChipUtil {
         return ((CraftEntity) en).getHandle();
     }
 
+    // For no discernible reason, the Mob field in these pathfinders
+    // is not final, unlike the mob fields in every other pathfinder.
+    // Since these classes each only have one mob field,
+    // we can simply ignore the "final" check in this case.
+
+    private static final List<Class<? extends PathfinderGoal>> NON_FINAL_ENTITY_FIELDS = ImmutableList.of(
+            PathfinderGoalAvoidTarget.class,
+            PathfinderGoalLookAtPlayer.class,
+            PathfinderGoalMeleeAttack.class,
+            PathfinderGoalDoorInteract.class
+    );
+
     public static Mob getEntity(PathfinderGoal g) {
-        // For no discernible reason, the Mob field in PathfinderGoalDoorInteract
-        // is not final, unlike the mob fields in every other pathfinder.
-        // Since PathfinderGoalDoorInteract and subclasses each only have one mob field,
-        // we can simply ignore the "final" check in this case.
-        boolean ignoreNonFinal = g instanceof PathfinderGoalDoorInteract;
+        boolean ignoreNonFinal = false;
+        for (Class<? extends PathfinderGoal> c : NON_FINAL_ENTITY_FIELDS) {
+            if (c.isAssignableFrom(g.getClass())) {
+                ignoreNonFinal = true;
+                break;
+            }
+        }
+
         try {
             Class<? extends PathfinderGoal> clazz = g.getClass();
 

--- a/1_13_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R2.java
+++ b/1_13_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R2.java
@@ -761,13 +761,18 @@ public class ChipUtil1_13_R2 implements ChipUtil {
     }
 
     public static Mob getEntity(PathfinderGoal g) {
+        // For no discernible reason, the Mob field in PathfinderGoalDoorInteract
+        // is not final, unlike the mob fields in every other pathfinder.
+        // Since PathfinderGoalDoorInteract and subclasses each only have one mob field,
+        // we can simply ignore the "final" check in this case.
+        boolean ignoreNonFinal = g instanceof PathfinderGoalDoorInteract;
         try {
             Class<? extends PathfinderGoal> clazz = g.getClass();
 
             while (clazz.getSuperclass() != null) {
                 for (Field f : clazz.getDeclaredFields()) {
                     f.setAccessible(true);
-                    if (EntityInsentient.class.isAssignableFrom(f.getType()) && Modifier.isFinal(f.getModifiers())) {
+                    if (EntityInsentient.class.isAssignableFrom(f.getType()) && (ignoreNonFinal || Modifier.isFinal(f.getModifiers()))) {
                         return fromNMS((EntityInsentient) f.get(g));
                     }
                 }
@@ -775,7 +780,6 @@ public class ChipUtil1_13_R2 implements ChipUtil {
                 if (PathfinderGoal.class.isAssignableFrom(clazz.getSuperclass())) clazz = (Class<? extends PathfinderGoal>) clazz.getSuperclass();
                 else break;
             }
-
             return null;
         } catch (Exception e) {
             Bukkit.getLogger().severe(e.getMessage());
@@ -879,7 +883,7 @@ public class ChipUtil1_13_R2 implements ChipUtil {
                 case "GotoTarget": return new PathfinderMoveToBlock((Creature) m, l -> fromNMS(getObject(g, "d", BlockPosition.class), m.getWorld()).equals(l), getDouble(g, "a"), getInt(g, "i"), getInt(g, "j"));
                 case "MoveTowardsRestriction": return new PathfinderMoveTowardsRestriction((Creature) m, getDouble(g, "e"));
                 case "MoveTowardsTarget": return new PathfinderMoveTowardsTarget((Creature) m, getDouble(g, "f"), getFloat(g, "g"));
-                case "OcelotAttack": return new PathfinderOcelotAttack((Ocelot) m);
+                case "OcelotAttack": return new PathfinderOcelotAttack(m);
                 case "OfferFlower": return new PathfinderOfferFlower((IronGolem) m);
                 case "Panic": return new PathfinderPanic((Creature) m, getDouble(g, "b"));
                 case "Perch": return new PathfinderRideShoulder((Parrot) m);

--- a/1_13_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R2.java
+++ b/1_13_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R2.java
@@ -1,5 +1,6 @@
 package me.gamercoder215.mobchip.abstraction;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import me.gamercoder215.mobchip.EntityBody;
 import me.gamercoder215.mobchip.abstraction.v1_13_R2.*;
@@ -760,12 +761,26 @@ public class ChipUtil1_13_R2 implements ChipUtil {
         }
     }
 
+    // For no discernible reason, the Mob field in these pathfinders
+    // is not final, unlike the mob fields in every other pathfinder.
+    // Since these classes each only have one mob field,
+    // we can simply ignore the "final" check in this case.
+    private static final List<Class<? extends PathfinderGoal>> NON_FINAL_ENTITY_FIELDS = ImmutableList.of(
+            PathfinderGoalAvoidTarget.class,
+            PathfinderGoalLookAtPlayer.class,
+            PathfinderGoalMeleeAttack.class,
+            PathfinderGoalDoorInteract.class
+    );
+
     public static Mob getEntity(PathfinderGoal g) {
-        // For no discernible reason, the Mob field in PathfinderGoalDoorInteract
-        // is not final, unlike the mob fields in every other pathfinder.
-        // Since PathfinderGoalDoorInteract and subclasses each only have one mob field,
-        // we can simply ignore the "final" check in this case.
-        boolean ignoreNonFinal = g instanceof PathfinderGoalDoorInteract;
+        boolean ignoreNonFinal = false;
+        for (Class<? extends PathfinderGoal> c : NON_FINAL_ENTITY_FIELDS) {
+            if (c.isAssignableFrom(g.getClass())) {
+                ignoreNonFinal = true;
+                break;
+            }
+        }
+
         try {
             Class<? extends PathfinderGoal> clazz = g.getClass();
 

--- a/1_14_R1/pom.xml
+++ b/1_14_R1/pom.xml
@@ -7,7 +7,7 @@
     </parent>
 
     <artifactId>mobchip-1_14_R1</artifactId>
-    <name>MobChip-1.14</name>
+    <name>MobChip-1.14.4</name>
 
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/1_14_R1/pom.xml
+++ b/1_14_R1/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.14-R0.1-SNAPSHOT</version>
+            <version>1.14.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_14_R1.java
+++ b/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_14_R1.java
@@ -126,7 +126,7 @@ public class ChipUtil1_14_R1 implements ChipUtil {
             .put(Mule.class, EntityHorseMule.class)
             .put(SkeletonHorse.class, EntityHorseSkeleton.class)
             .put(Stray.class, EntitySkeletonStray.class)
-            .put(TraderLlama.class, EntityLLamaTrader.class)
+            .put(TraderLlama.class, EntityLlamaTrader.class)
             .put(WanderingTrader.class, EntityVillagerTrader.class)
             .put(WitherSkeleton.class, EntitySkeletonWither.class)
             .put(ZombieHorse.class, EntityHorseZombie.class)
@@ -482,16 +482,11 @@ public class ChipUtil1_14_R1 implements ChipUtil {
     }
 
     public static <T extends EntityLiving> Behavior<T> toNMS(Consumer<Mob> en) {
-        return new Behavior<T>() {
+        return new Behavior<T>(Collections.emptyMap()) {
             @Override
             protected void d(WorldServer var0, T m, long var2) {
                 if (!(m instanceof EntityInsentient)) return;
                 en.accept(fromNMS((EntityInsentient) m));
-            }
-
-            @Override
-            protected Set<Pair<MemoryModuleType<?>, MemoryStatus>> a() {
-                return Collections.emptySet();
             }
         };
     }
@@ -617,9 +612,9 @@ public class ChipUtil1_14_R1 implements ChipUtil {
 
         if (nmsValue instanceof GlobalPos) {
             GlobalPos l = (GlobalPos) nmsValue;
-            BlockPosition pos = l.b();
+            BlockPosition pos = l.getBlockPosition();
 
-            org.bukkit.World w = Bukkit.getWorld(DimensionManager.a(l.a()).getKey());
+            org.bukkit.World w = Bukkit.getWorld(DimensionManager.a(l.getDimensionManager()).getKey());
             value = new Location(w, pos.getX(), pos.getY(), pos.getZ());
         }
         else if (nmsValue instanceof EntityHuman) {
@@ -759,7 +754,7 @@ public class ChipUtil1_14_R1 implements ChipUtil {
         String key = IRegistry.MEMORY_MODULE_TYPE.getKey(type).getKey();
         Object nmsValue = toNMS(key, value);
 
-        nms.getBehaviorController().a(type, nmsValue);
+        nms.getBehaviorController().setMemory(type, nmsValue);
     }
 
     @Override
@@ -780,8 +775,7 @@ public class ChipUtil1_14_R1 implements ChipUtil {
         MemoryModuleType type = toNMS(m);
         String key = IRegistry.MEMORY_MODULE_TYPE.getKey(type).getKey();
 
-        Optional<?> o = nms.getBehaviorController().c(type);
-        return o.map(value -> m.getBukkitClass().cast(fromNMS(mob, key, value))).orElse(null);
+        return m.getBukkitClass().cast(fromNMS(mob, key, nms.getBehaviorController().getMemory(type)));
     }
 
     @Override
@@ -795,14 +789,14 @@ public class ChipUtil1_14_R1 implements ChipUtil {
         EntityInsentient nms = toNMS(mob);
         MemoryModuleType type = toNMS(m);
 
-        return nms.getBehaviorController().a(type);
+        return nms.getBehaviorController().hasMemory(type);
     }
 
     @Override
     public void removeMemory(Mob mob, Memory<?> m) {
         EntityInsentient nms = toNMS(mob);
         MemoryModuleType<?> type = toNMS(m);
-        nms.getBehaviorController().b(type);
+        nms.getBehaviorController().removeMemory(type);
     }
 
     @Override
@@ -1049,13 +1043,18 @@ public class ChipUtil1_14_R1 implements ChipUtil {
     }
 
     public static Mob getEntity(PathfinderGoal g) {
+        // For no discernible reason, the Mob field in PathfinderGoalDoorInteract
+        // is not final, unlike the mob fields in every other pathfinder.
+        // Since PathfinderGoalDoorInteract and subclasses each only have one mob field,
+        // we can simply ignore the "final" check in this case.
+        boolean ignoreNonFinal = g instanceof PathfinderGoalDoorInteract;
         try {
             Class<? extends PathfinderGoal> clazz = g.getClass();
 
             while (clazz.getSuperclass() != null) {
                 for (Field f : clazz.getDeclaredFields()) {
                     f.setAccessible(true);
-                    if (EntityInsentient.class.isAssignableFrom(f.getType()) && Modifier.isFinal(f.getModifiers())) {
+                    if (EntityInsentient.class.isAssignableFrom(f.getType()) && (ignoreNonFinal || Modifier.isFinal(f.getModifiers()))) {
                         return fromNMS((EntityInsentient) f.get(g));
                     }
                 }
@@ -1063,7 +1062,6 @@ public class ChipUtil1_14_R1 implements ChipUtil {
                 if (PathfinderGoal.class.isAssignableFrom(clazz.getSuperclass())) clazz = (Class<? extends PathfinderGoal>) clazz.getSuperclass();
                 else break;
             }
-
             return null;
         } catch (Exception e) {
             Bukkit.getLogger().severe(e.getMessage());
@@ -1175,7 +1173,7 @@ public class ChipUtil1_14_R1 implements ChipUtil {
                 case "FollowParent": return new PathfinderFollowParent((Animals) m, getDouble(g, "c"));
                 case "HorseTrap": return new PathfinderSkeletonTrap((SkeletonHorse) m);
                 case "LeapAtTarget": return new PathfinderLeapAtTarget(m, getFloat(g, "c"));
-                case "JumpOnBlock": return new PathfinderCatOnBlock((Cat) m, getDouble(g, "g"));
+                case "JumpOnBlock": return new PathfinderCatOnBlock((Cat) m, getDouble(g, "b"));
                 case "LlamaFollow": return new PathfinderLlamaFollowCaravan((Llama) m, getDouble(g, "b"));
                 case "LookAtPlayer": return new PathfinderLookAtEntity<>(m, fromNMS(getObject(g, "d", Class.class), LivingEntity.class), getFloat(g, "c"), getFloat(g, "g"));
                 case "LookAtTradingPlayer": return new PathfinderLookAtTradingPlayer((AbstractVillager) m);
@@ -1186,7 +1184,7 @@ public class ChipUtil1_14_R1 implements ChipUtil {
                 case "Raid": return new PathfinderMoveToRaid((Raider) m);
                 case "MoveTowardsRestriction": return new PathfinderMoveTowardsRestriction((Creature) m, getDouble(g, "e"));
                 case "MoveTowardsTarget": return new PathfinderMoveTowardsTarget((Creature) m, getDouble(g, "f"), getFloat(g, "g"));
-                case "OcelotAttack": return new PathfinderOcelotAttack((Ocelot) m);
+                case "OcelotAttack": return new PathfinderOcelotAttack(m);
                 case "OfferFlower": return new PathfinderOfferFlower((IronGolem) m);
                 case "Panic": return new PathfinderPanic((Creature) m, getDouble(g, "b"));
                 case "Perch": return new PathfinderRideShoulder((Parrot) m);
@@ -1252,7 +1250,7 @@ public class ChipUtil1_14_R1 implements ChipUtil {
     }
 
     public static GossipType fromNMS(ReputationType t) {
-        return GossipType.getByKey(NamespacedKey.minecraft(t.g));
+        return GossipType.getByKey(NamespacedKey.minecraft(t.f));
     }
 
     @Override
@@ -1372,7 +1370,7 @@ public class ChipUtil1_14_R1 implements ChipUtil {
 
             Supplier<Sensor<?>> sup = () -> toNMS(s);
 
-            return (SensorType<?>) c.newInstance(sup);
+            return c.newInstance(sup);
         } catch (ReflectiveOperationException e) {
             Bukkit.getLogger().severe(e.getMessage());
             for (StackTraceElement st : e.getStackTrace()) Bukkit.getLogger().severe(st.toString());
@@ -1387,7 +1385,7 @@ public class ChipUtil1_14_R1 implements ChipUtil {
     }
 
     public static NamespacedKey fromNMS(MinecraftKey loc) {
-        return new NamespacedKey(loc.b(), loc.getKey());
+        return new NamespacedKey(loc.getNamespace(), loc.getKey());
     }
 
     public static Memory<?> fromNMS(MemoryModuleType<?> memory) {

--- a/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_14_R1/AttributeInstance1_14_R1.java
+++ b/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_14_R1/AttributeInstance1_14_R1.java
@@ -26,7 +26,7 @@ public class AttributeInstance1_14_R1 implements me.gamercoder215.mobchip.ai.att
 
     @Override
     public double getBaseValue() {
-        return handle.b();
+        return handle.getBaseValue();
     }
 
     @Override
@@ -37,19 +37,19 @@ public class AttributeInstance1_14_R1 implements me.gamercoder215.mobchip.ai.att
     @NotNull
     @Override
     public Collection<AttributeModifier> getModifiers() {
-        return handle.c().stream().map(CraftAttributeInstance::convert).collect(Collectors.toSet());
+        return handle.getModifiers().stream().map(CraftAttributeInstance::convert).collect(Collectors.toSet());
     }
 
     @Override
     public void addModifier(@NotNull AttributeModifier mod) {
         Preconditions.checkArgument(mod != null, "modifier");
-        handle.b(CraftAttributeInstance.convert(mod));
+        handle.addModifier(CraftAttributeInstance.convert(mod));
     }
 
     @Override
     public void removeModifier(@NotNull AttributeModifier mod) {
         Preconditions.checkArgument(mod != null, "modifier");
-        handle.c(CraftAttributeInstance.convert(mod));
+        handle.removeModifier(CraftAttributeInstance.convert(mod));
     }
 
     @Override

--- a/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_14_R1/BehaviorResult1_14_R1.java
+++ b/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_14_R1/BehaviorResult1_14_R1.java
@@ -24,7 +24,7 @@ public final class BehaviorResult1_14_R1 extends BehaviorResult {
 
     @Override
     public @NotNull Status getStatus() {
-        return ChipUtil1_14_R1.fromNMS(b.b());
+        return ChipUtil1_14_R1.fromNMS(b.a());
     }
 
     @Override

--- a/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_14_R1/EntityBody1_14_R1.java
+++ b/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_14_R1/EntityBody1_14_R1.java
@@ -60,7 +60,7 @@ public final class EntityBody1_14_R1 implements EntityBody {
 
     @Override
     public boolean canBreatheUnderwater() {
-        return nmsMob.cB();
+        return nmsMob.cC();
     }
 
     @Override
@@ -139,7 +139,7 @@ public final class EntityBody1_14_R1 implements EntityBody {
 
     @Override
     public boolean canRideUnderwater() {
-        return nmsMob.be();
+        return nmsMob.bf();
     }
 
     @Override
@@ -342,7 +342,7 @@ public final class EntityBody1_14_R1 implements EntityBody {
 
     @Override
     public boolean isImmuneToExplosions() {
-        return nmsMob.bR();
+        return nmsMob.bS();
     }
 
     @Override
@@ -368,7 +368,7 @@ public final class EntityBody1_14_R1 implements EntityBody {
 
     @Override
     public int getMaxFallDistance() {
-        return nmsMob.bu();
+        return nmsMob.bv();
     }
 
     @Override
@@ -511,7 +511,7 @@ public final class EntityBody1_14_R1 implements EntityBody {
         } catch (ReflectiveOperationException e) {
             Bukkit.getLogger().severe(e.getMessage());
             for (StackTraceElement ste : e.getStackTrace()) Bukkit.getLogger().severe(ste.toString());
-        }       
+        }
     }
 
 }

--- a/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_14_R1/EntityNavigation1_14_R1.java
+++ b/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_14_R1/EntityNavigation1_14_R1.java
@@ -76,7 +76,7 @@ public final class EntityNavigation1_14_R1 implements EntityNavigation {
     @Override
     @NotNull
     public NavigationPath buildPath() {
-        return new NavigationPath1_14_R1(handle.a(finalPos.getX(), finalPos.getY(), finalPos.getZ()), m);
+        return new NavigationPath1_14_R1(handle.a(finalPos, range), m);
     }
 
     @Override

--- a/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_14_R1/EntityScheduleManager1_14_R1.java
+++ b/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_14_R1/EntityScheduleManager1_14_R1.java
@@ -26,12 +26,12 @@ public final class EntityScheduleManager1_14_R1 implements EntityScheduleManager
 
     @Override
     public @Nullable me.gamercoder215.mobchip.ai.schedule.Schedule getCurrentSchedule() {
-        return ChipUtil1_14_R1.fromNMS(nmsMob.getBehaviorController().b());
+        return ChipUtil1_14_R1.fromNMS(nmsMob.getBehaviorController().getSchedule());
     }
 
     @Override
     public void setSchedule(@NotNull me.gamercoder215.mobchip.ai.schedule.Schedule s) {
-        nmsMob.getBehaviorController().a(ChipUtil1_14_R1.toNMS(s));
+        nmsMob.getBehaviorController().setSchedule(ChipUtil1_14_R1.toNMS(s));
     }
 
     @Override

--- a/1_14_R1/src/test/java/me/gamercoder215/mobchip/abstraction/TestChipUtil1_14_R1.java
+++ b/1_14_R1/src/test/java/me/gamercoder215/mobchip/abstraction/TestChipUtil1_14_R1.java
@@ -40,10 +40,7 @@ public class TestChipUtil1_14_R1 {
     public void testBukkitConversion() {
         // Other
         for (EnumDifficulty d : EnumDifficulty.values()) Assertions.assertNotNull(ChipUtil1_14_R1.fromNMS(d));
-        for (ReputationType t : ReputationType.values()) {
-            if (t == ReputationType.GOLEM) continue; // Only exists in 1.14
-            Assertions.assertNotNull(ChipUtil1_14_R1.fromNMS(t));
-        }
+        for (ReputationType t : ReputationType.values())Assertions.assertNotNull(ChipUtil1_14_R1.fromNMS(t));
     }
-    
+
 }

--- a/1_15_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_15_R1.java
+++ b/1_15_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_15_R1.java
@@ -1044,13 +1044,18 @@ public class ChipUtil1_15_R1 implements ChipUtil {
     }
 
     public static Mob getEntity(PathfinderGoal g) {
+        // For no discernible reason, the Mob field in PathfinderGoalDoorInteract
+        // is not final, unlike the mob fields in every other pathfinder.
+        // Since PathfinderGoalDoorInteract and subclasses each only have one mob field,
+        // we can simply ignore the "final" check in this case.
+        boolean ignoreNonFinal = g instanceof PathfinderGoalDoorInteract;
         try {
             Class<? extends PathfinderGoal> clazz = g.getClass();
 
             while (clazz.getSuperclass() != null) {
                 for (Field f : clazz.getDeclaredFields()) {
                     f.setAccessible(true);
-                    if (EntityInsentient.class.isAssignableFrom(f.getType()) && Modifier.isFinal(f.getModifiers())) {
+                    if (EntityInsentient.class.isAssignableFrom(f.getType()) && (ignoreNonFinal || Modifier.isFinal(f.getModifiers()))) {
                         return fromNMS((EntityInsentient) f.get(g));
                     }
                 }
@@ -1058,7 +1063,6 @@ public class ChipUtil1_15_R1 implements ChipUtil {
                 if (PathfinderGoal.class.isAssignableFrom(clazz.getSuperclass())) clazz = (Class<? extends PathfinderGoal>) clazz.getSuperclass();
                 else break;
             }
-
             return null;
         } catch (Exception e) {
             Bukkit.getLogger().severe(e.getMessage());
@@ -1171,7 +1175,7 @@ public class ChipUtil1_15_R1 implements ChipUtil {
                 case "FollowParent": return new PathfinderFollowParent((Animals) m, getDouble(g, "c"));
                 case "HorseTrap": return new PathfinderSkeletonTrap((SkeletonHorse) m);
                 case "LeapAtTarget": return new PathfinderLeapAtTarget(m, getFloat(g, "c"));
-                case "JumpOnBlock": return new PathfinderCatOnBlock((Cat) m, getDouble(g, "g"));
+                case "JumpOnBlock": return new PathfinderCatOnBlock((Cat) m, getDouble(g, "b"));
                 case "LlamaFollow": return new PathfinderLlamaFollowCaravan((Llama) m, getDouble(g, "b"));
                 case "LookAtPlayer": return new PathfinderLookAtEntity<>(m, fromNMS(getObject(g, "e", Class.class), LivingEntity.class), getFloat(g, "c"), getFloat(g, "d"));
                 case "LookAtTradingPlayer": return new PathfinderLookAtTradingPlayer((AbstractVillager) m);
@@ -1182,7 +1186,7 @@ public class ChipUtil1_15_R1 implements ChipUtil {
                 case "Raid": return new PathfinderMoveToRaid((Raider) m);
                 case "MoveTowardsRestriction": return new PathfinderMoveTowardsRestriction((Creature) m, getDouble(g, "e"));
                 case "MoveTowardsTarget": return new PathfinderMoveTowardsTarget((Creature) m, getDouble(g, "f"), getFloat(g, "g"));
-                case "OcelotAttack": return new PathfinderOcelotAttack((Ocelot) m);
+                case "OcelotAttack": return new PathfinderOcelotAttack(m);
                 case "OfferFlower": return new PathfinderOfferFlower((IronGolem) m);
                 case "Panic": return new PathfinderPanic((Creature) m, getDouble(g, "b"));
                 case "Perch": return new PathfinderRideShoulder((Parrot) m);

--- a/1_16_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R1.java
+++ b/1_16_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R1.java
@@ -1069,13 +1069,18 @@ public class ChipUtil1_16_R1 implements ChipUtil {
     }
 
     public static Mob getEntity(PathfinderGoal g) {
+        // For no discernible reason, the Mob field in PathfinderGoalDoorInteract
+        // is not final, unlike the mob fields in every other pathfinder.
+        // Since PathfinderGoalDoorInteract and subclasses each only have one mob field,
+        // we can simply ignore the "final" check in this case.
+        boolean ignoreNonFinal = g instanceof PathfinderGoalDoorInteract;
         try {
             Class<? extends PathfinderGoal> clazz = g.getClass();
 
             while (clazz.getSuperclass() != null) {
                 for (Field f : clazz.getDeclaredFields()) {
                     f.setAccessible(true);
-                    if (EntityInsentient.class.isAssignableFrom(f.getType()) && Modifier.isFinal(f.getModifiers())) {
+                    if (EntityInsentient.class.isAssignableFrom(f.getType()) && (ignoreNonFinal || Modifier.isFinal(f.getModifiers()))) {
                         return fromNMS((EntityInsentient) f.get(g));
                     }
                 }
@@ -1083,7 +1088,6 @@ public class ChipUtil1_16_R1 implements ChipUtil {
                 if (PathfinderGoal.class.isAssignableFrom(clazz.getSuperclass())) clazz = (Class<? extends PathfinderGoal>) clazz.getSuperclass();
                 else break;
             }
-
             return null;
         } catch (Exception e) {
             Bukkit.getLogger().severe(e.getMessage());
@@ -1198,7 +1202,7 @@ public class ChipUtil1_16_R1 implements ChipUtil {
                 case "FollowParent": return new PathfinderFollowParent((Animals) m, getDouble(g, "c"));
                 case "HorseTrap": return new PathfinderSkeletonTrap((SkeletonHorse) m);
                 case "LeapAtTarget": return new PathfinderLeapAtTarget(m, getFloat(g, "c"));
-                case "JumpOnBlock": return new PathfinderCatOnBlock((Cat) m, getDouble(g, "g"));
+                case "JumpOnBlock": return new PathfinderCatOnBlock((Cat) m, getDouble(g, "b"));
                 case "LlamaFollow": return new PathfinderLlamaFollowCaravan((Llama) m, getDouble(g, "b"));
                 case "LookAtPlayer": return new PathfinderLookAtEntity<>(m, fromNMS(getObject(g, "e", Class.class), LivingEntity.class), getFloat(g, "c"), getFloat(g, "d"));
                 case "LookAtTradingPlayer": return new PathfinderLookAtTradingPlayer((AbstractVillager) m);
@@ -1209,7 +1213,7 @@ public class ChipUtil1_16_R1 implements ChipUtil {
                 case "Raid": return new PathfinderMoveToRaid((Raider) m);
                 case "MoveTowardsRestriction": return new PathfinderMoveTowardsRestriction((Creature) m, getDouble(g, "e"));
                 case "MoveTowardsTarget": return new PathfinderMoveTowardsTarget((Creature) m, getDouble(g, "f"), getFloat(g, "g"));
-                case "OcelotAttack": return new PathfinderOcelotAttack((Ocelot) m);
+                case "OcelotAttack": return new PathfinderOcelotAttack(m);
                 case "OfferFlower": return new PathfinderOfferFlower((IronGolem) m);
                 case "Panic": return new PathfinderPanic((Creature) m, getDouble(g, "b"));
                 case "Perch": return new PathfinderRideShoulder((Parrot) m);

--- a/1_16_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R2.java
+++ b/1_16_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R2.java
@@ -1065,13 +1065,18 @@ public class ChipUtil1_16_R2 implements ChipUtil {
     }
 
     public static Mob getEntity(PathfinderGoal g) {
+        // For no discernible reason, the Mob field in PathfinderGoalDoorInteract
+        // is not final, unlike the mob fields in every other pathfinder.
+        // Since PathfinderGoalDoorInteract and subclasses each only have one mob field,
+        // we can simply ignore the "final" check in this case.
+        boolean ignoreNonFinal = g instanceof PathfinderGoalDoorInteract;
         try {
             Class<? extends PathfinderGoal> clazz = g.getClass();
 
             while (clazz.getSuperclass() != null) {
                 for (Field f : clazz.getDeclaredFields()) {
                     f.setAccessible(true);
-                    if (EntityInsentient.class.isAssignableFrom(f.getType()) && Modifier.isFinal(f.getModifiers())) {
+                    if (EntityInsentient.class.isAssignableFrom(f.getType()) && (ignoreNonFinal || Modifier.isFinal(f.getModifiers()))) {
                         return fromNMS((EntityInsentient) f.get(g));
                     }
                 }
@@ -1079,7 +1084,6 @@ public class ChipUtil1_16_R2 implements ChipUtil {
                 if (PathfinderGoal.class.isAssignableFrom(clazz.getSuperclass())) clazz = (Class<? extends PathfinderGoal>) clazz.getSuperclass();
                 else break;
             }
-
             return null;
         } catch (Exception e) {
             Bukkit.getLogger().severe(e.getMessage());
@@ -1195,7 +1199,7 @@ public class ChipUtil1_16_R2 implements ChipUtil {
                 case "FollowParent": return new PathfinderFollowParent((Animals) m, getDouble(g, "c"));
                 case "HorseTrap": return new PathfinderSkeletonTrap((SkeletonHorse) m);
                 case "LeapAtTarget": return new PathfinderLeapAtTarget(m, getFloat(g, "c"));
-                case "JumpOnBlock": return new PathfinderCatOnBlock((Cat) m, getDouble(g, "g"));
+                case "JumpOnBlock": return new PathfinderCatOnBlock((Cat) m, getDouble(g, "b"));
                 case "LlamaFollow": return new PathfinderLlamaFollowCaravan((Llama) m, getDouble(g, "b"));
                 case "LookAtPlayer": return new PathfinderLookAtEntity<>(m, fromNMS(getObject(g, "e", Class.class), LivingEntity.class), getFloat(g, "c"), getFloat(g, "d"));
                 case "LookAtTradingPlayer": return new PathfinderLookAtTradingPlayer((AbstractVillager) m);
@@ -1206,7 +1210,7 @@ public class ChipUtil1_16_R2 implements ChipUtil {
                 case "Raid": return new PathfinderMoveToRaid((Raider) m);
                 case "MoveTowardsRestriction": return new PathfinderMoveTowardsRestriction((Creature) m, getDouble(g, "e"));
                 case "MoveTowardsTarget": return new PathfinderMoveTowardsTarget((Creature) m, getDouble(g, "f"), getFloat(g, "g"));
-                case "OcelotAttack": return new PathfinderOcelotAttack((Ocelot) m);
+                case "OcelotAttack": return new PathfinderOcelotAttack(m);
                 case "OfferFlower": return new PathfinderOfferFlower((IronGolem) m);
                 case "Panic": return new PathfinderPanic((Creature) m, getDouble(g, "b"));
                 case "Perch": return new PathfinderRideShoulder((Parrot) m);

--- a/1_16_R3/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R3.java
+++ b/1_16_R3/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R3.java
@@ -1047,13 +1047,18 @@ public class ChipUtil1_16_R3 implements ChipUtil {
     public static Sound fromNMS(SoundEffect s) { return CraftSound.getBukkit(s); }
 
     public static Mob getEntity(PathfinderGoal g) {
+        // For no discernible reason, the Mob field in PathfinderGoalDoorInteract
+        // is not final, unlike the mob fields in every other pathfinder.
+        // Since PathfinderGoalDoorInteract and subclasses each only have one mob field,
+        // we can simply ignore the "final" check in this case.
+        boolean ignoreNonFinal = g instanceof PathfinderGoalDoorInteract;
         try {
             Class<? extends PathfinderGoal> clazz = g.getClass();
 
             while (clazz.getSuperclass() != null) {
                 for (Field f : clazz.getDeclaredFields()) {
                     f.setAccessible(true);
-                    if (EntityInsentient.class.isAssignableFrom(f.getType()) && Modifier.isFinal(f.getModifiers())) {
+                    if (EntityInsentient.class.isAssignableFrom(f.getType()) && (ignoreNonFinal || Modifier.isFinal(f.getModifiers()))) {
                         return fromNMS((EntityInsentient) f.get(g));
                     }
                 }
@@ -1061,7 +1066,6 @@ public class ChipUtil1_16_R3 implements ChipUtil {
                 if (PathfinderGoal.class.isAssignableFrom(clazz.getSuperclass())) clazz = (Class<? extends PathfinderGoal>) clazz.getSuperclass();
                 else break;
             }
-
             return null;
         } catch (Exception e) {
             Bukkit.getLogger().severe(e.getMessage());
@@ -1177,7 +1181,7 @@ public class ChipUtil1_16_R3 implements ChipUtil {
                 case "FollowParent": return new PathfinderFollowParent((Animals) m, getDouble(g, "c"));
                 case "HorseTrap": return new PathfinderSkeletonTrap((SkeletonHorse) m);
                 case "LeapAtTarget": return new PathfinderLeapAtTarget(m, getFloat(g, "c"));
-                case "JumpOnBlock": return new PathfinderCatOnBlock((Cat) m, getDouble(g, "g"));
+                case "JumpOnBlock": return new PathfinderCatOnBlock((Cat) m, getDouble(g, "b"));
                 case "LlamaFollow": return new PathfinderLlamaFollowCaravan((Llama) m, getDouble(g, "b"));
                 case "LookAtPlayer": return new PathfinderLookAtEntity<>(m, fromNMS(getObject(g, "e", Class.class), LivingEntity.class), getFloat(g, "c"), getFloat(g, "d"));
                 case "LookAtTradingPlayer": return new PathfinderLookAtTradingPlayer((AbstractVillager) m);
@@ -1188,7 +1192,7 @@ public class ChipUtil1_16_R3 implements ChipUtil {
                 case "Raid": return new PathfinderMoveToRaid((Raider) m);
                 case "MoveTowardsRestriction": return new PathfinderMoveTowardsRestriction((Creature) m, getDouble(g, "e"));
                 case "MoveTowardsTarget": return new PathfinderMoveTowardsTarget((Creature) m, getDouble(g, "f"), getFloat(g, "g"));
-                case "OcelotAttack": return new PathfinderOcelotAttack((Ocelot) m);
+                case "OcelotAttack": return new PathfinderOcelotAttack(m);
                 case "OfferFlower": return new PathfinderOfferFlower((IronGolem) m);
                 case "Panic": return new PathfinderPanic((Creature) m, getDouble(g, "b"));
                 case "Perch": return new PathfinderRideShoulder((Parrot) m);

--- a/1_17_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_17_R1.java
+++ b/1_17_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_17_R1.java
@@ -1131,13 +1131,18 @@ public final class ChipUtil1_17_R1 implements ChipUtil {
     public static Sound fromNMS(SoundEffect s) { return CraftSound.getBukkit(s); }
 
     public static Mob getEntity(PathfinderGoal g) {
+        // For no discernible reason, the Mob field in PathfinderGoalDoorInteract
+        // is not final, unlike the mob fields in every other pathfinder.
+        // Since PathfinderGoalDoorInteract and subclasses each only have one mob field,
+        // we can simply ignore the "final" check in this case.
+        boolean ignoreNonFinal = g instanceof PathfinderGoalDoorInteract;
         try {
             Class<? extends PathfinderGoal> clazz = g.getClass();
 
             while (clazz.getSuperclass() != null) {
                 for (Field f : clazz.getDeclaredFields()) {
                     f.setAccessible(true);
-                    if (EntityInsentient.class.isAssignableFrom(f.getType()) && Modifier.isFinal(f.getModifiers())) {
+                    if (EntityInsentient.class.isAssignableFrom(f.getType()) && (ignoreNonFinal || Modifier.isFinal(f.getModifiers()))) {
                         return fromNMS((EntityInsentient) f.get(g));
                     }
                 }
@@ -1145,7 +1150,6 @@ public final class ChipUtil1_17_R1 implements ChipUtil {
                 if (PathfinderGoal.class.isAssignableFrom(clazz.getSuperclass())) clazz = (Class<? extends PathfinderGoal>) clazz.getSuperclass();
                 else break;
             }
-
             return null;
         } catch (Exception e) {
             Bukkit.getLogger().severe(e.getMessage());
@@ -1260,7 +1264,7 @@ public final class ChipUtil1_17_R1 implements ChipUtil {
                 case "FollowParent" -> new PathfinderFollowParent((Animals) m, getDouble(g, "f"));
                 case "HorseTrap" -> new PathfinderSkeletonTrap((SkeletonHorse) m);
                 case "LeapAtTarget" -> new PathfinderLeapAtTarget(m, getFloat(g, "c"));
-                case "JumpOnBlock" -> new PathfinderCatOnBlock((Cat) m, getDouble(g, "g"));
+                case "JumpOnBlock" -> new PathfinderCatOnBlock((Cat) m, getDouble(g, "b"));
                 case "LlamaFollow" -> new PathfinderLlamaFollowCaravan((Llama) m, getDouble(g, "b"));
                 case "LookAtPlayer" -> new PathfinderLookAtEntity<>(m, fromNMS(getObject(g, "f", Class.class), LivingEntity.class), getFloat(g, "d"), getFloat(g, "e"), getBoolean(g, "i"));
                 case "LookAtTradingPlayer" -> new PathfinderLookAtTradingPlayer((AbstractVillager) m);
@@ -1271,7 +1275,7 @@ public final class ChipUtil1_17_R1 implements ChipUtil {
                 case "Raid" -> new PathfinderMoveToRaid((Raider) m);
                 case "MoveTowardsRestriction" -> new PathfinderMoveTowardsRestriction((Creature) m, getDouble(g, "e"));
                 case "MoveTowardsTarget" -> new PathfinderMoveTowardsTarget((Creature) m, getDouble(g, "f"), getFloat(g, "g"));
-                case "OcelotAttack" -> new PathfinderOcelotAttack((Ocelot) m);
+                case "OcelotAttack" -> new PathfinderOcelotAttack(m);
                 case "OfferFlower" -> new PathfinderOfferFlower((IronGolem) m);
                 case "Panic" -> new PathfinderPanic((Creature) m, getDouble(g, "c"));
                 case "Perch" -> new PathfinderRideShoulder((Parrot) m);

--- a/1_18_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R1.java
+++ b/1_18_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R1.java
@@ -1128,13 +1128,18 @@ public final class ChipUtil1_18_R1 implements ChipUtil {
     public static Sound fromNMS(SoundEvent s) { return CraftSound.getBukkit(s); }
 
     public static Mob getEntity(Goal g) {
+        // For no discernible reason, the Mob field in DoorInteractGoal
+        // is not final, unlike the mob fields in every other pathfinder.
+        // Since DoorInteractGoal and subclasses each only have one mob field,
+        // we can simply ignore the "final" check in this case.
+        boolean ignoreNonFinal = g instanceof DoorInteractGoal;
         try {
             Class<? extends Goal> clazz = g.getClass();
 
             while (clazz.getSuperclass() != null) {
                 for (Field f : clazz.getDeclaredFields()) {
                     f.setAccessible(true);
-                    if (net.minecraft.world.entity.Mob.class.isAssignableFrom(f.getType()) && Modifier.isFinal(f.getModifiers())) {
+                    if (net.minecraft.world.entity.Mob.class.isAssignableFrom(f.getType()) && (ignoreNonFinal || Modifier.isFinal(f.getModifiers()))) {
                         return fromNMS((net.minecraft.world.entity.Mob) f.get(g));
                     }
                 }
@@ -1142,7 +1147,6 @@ public final class ChipUtil1_18_R1 implements ChipUtil {
                 if (Goal.class.isAssignableFrom(clazz.getSuperclass())) clazz = (Class<? extends Goal>) clazz.getSuperclass();
                 else break;
             }
-
             return null;
         } catch (Exception e) {
             Bukkit.getLogger().severe(e.getMessage());
@@ -1255,7 +1259,7 @@ public final class ChipUtil1_18_R1 implements ChipUtil {
                 case "FollowParent" -> new PathfinderFollowParent((Animals) m, getDouble(g, "f"));
                 case "HorseTrap" -> new PathfinderSkeletonTrap((SkeletonHorse) m);
                 case "LeapAtTarget" -> new PathfinderLeapAtTarget(m, getFloat(g, "c"));
-                case "JumpOnBlock" -> new PathfinderCatOnBlock((Cat) m, getDouble(g, "g"));
+                case "JumpOnBlock" -> new PathfinderCatOnBlock((Cat) m, getDouble(g, "b"));
                 case "LlamaFollow" -> new PathfinderLlamaFollowCaravan((Llama) m, getDouble(g, "b"));
                 case "LookAtPlayer" -> new PathfinderLookAtEntity<>(m, fromNMS(getObject(g, "f", Class.class), LivingEntity.class), getFloat(g, "d"), getFloat(g, "e"), getBoolean(g, "i"));
                 case "LookAtTradingPlayer" -> new PathfinderLookAtTradingPlayer((AbstractVillager) m);
@@ -1266,7 +1270,7 @@ public final class ChipUtil1_18_R1 implements ChipUtil {
                 case "Raid" -> new PathfinderMoveToRaid((Raider) m);
                 case "MoveTowardsRestriction" -> new PathfinderMoveTowardsRestriction((Creature) m, getDouble(g, "e"));
                 case "MoveTowardsTarget" -> new PathfinderMoveTowardsTarget((Creature) m, getDouble(g, "f"), getFloat(g, "g"));
-                case "OcelotAttack" -> new PathfinderOcelotAttack((Ocelot) m);
+                case "OcelotAttack" -> new PathfinderOcelotAttack(m);
                 case "OfferFlower" -> new PathfinderOfferFlower((IronGolem) m);
                 case "Panic" -> new PathfinderPanic((Creature) m, getDouble(g, "c"));
                 case "Perch" -> new PathfinderRideShoulder((Parrot) m);

--- a/1_18_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R2.java
+++ b/1_18_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R2.java
@@ -1128,13 +1128,18 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
     public static Sound fromNMS(SoundEvent s) { return CraftSound.getBukkit(s); }
 
     public static Mob getEntity(Goal g) {
+        // For no discernible reason, the Mob field in DoorInteractGoal
+        // is not final, unlike the mob fields in every other pathfinder.
+        // Since DoorInteractGoal and subclasses each only have one mob field,
+        // we can simply ignore the "final" check in this case.
+        boolean ignoreNonFinal = g instanceof DoorInteractGoal;
         try {
             Class<? extends Goal> clazz = g.getClass();
 
             while (clazz.getSuperclass() != null) {
                 for (Field f : clazz.getDeclaredFields()) {
                     f.setAccessible(true);
-                    if (net.minecraft.world.entity.Mob.class.isAssignableFrom(f.getType()) && Modifier.isFinal(f.getModifiers())) {
+                    if (net.minecraft.world.entity.Mob.class.isAssignableFrom(f.getType()) && (ignoreNonFinal || Modifier.isFinal(f.getModifiers()))) {
                         return fromNMS((net.minecraft.world.entity.Mob) f.get(g));
                     }
                 }
@@ -1142,7 +1147,6 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
                 if (Goal.class.isAssignableFrom(clazz.getSuperclass())) clazz = (Class<? extends Goal>) clazz.getSuperclass();
                 else break;
             }
-
             return null;
         } catch (Exception e) {
             Bukkit.getLogger().severe(e.getMessage());
@@ -1256,7 +1260,7 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
                 case "FollowParent" -> new PathfinderFollowParent((Animals) m, getDouble(g, "f"));
                 case "HorseTrap" -> new PathfinderSkeletonTrap((SkeletonHorse) m);
                 case "LeapAtTarget" -> new PathfinderLeapAtTarget(m, getFloat(g, "c"));
-                case "JumpOnBlock" -> new PathfinderCatOnBlock((Cat) m, getDouble(g, "g"));
+                case "JumpOnBlock" -> new PathfinderCatOnBlock((Cat) m, getDouble(g, "b"));
                 case "LlamaFollow" -> new PathfinderLlamaFollowCaravan((Llama) m, getDouble(g, "b"));
                 case "LookAtPlayer" -> new PathfinderLookAtEntity<>(m, fromNMS(getObject(g, "f", Class.class), LivingEntity.class), getFloat(g, "d"), getFloat(g, "e"), getBoolean(g, "i"));
                 case "LookAtTradingPlayer" -> new PathfinderLookAtTradingPlayer((AbstractVillager) m);
@@ -1267,7 +1271,7 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
                 case "Raid" -> new PathfinderMoveToRaid((Raider) m);
                 case "MoveTowardsRestriction" -> new PathfinderMoveTowardsRestriction((Creature) m, getDouble(g, "e"));
                 case "MoveTowardsTarget" -> new PathfinderMoveTowardsTarget((Creature) m, getDouble(g, "f"), getFloat(g, "g"));
-                case "OcelotAttack" -> new PathfinderOcelotAttack((Ocelot) m);
+                case "OcelotAttack" -> new PathfinderOcelotAttack(m);
                 case "OfferFlower" -> new PathfinderOfferFlower((IronGolem) m);
                 case "Panic" -> new PathfinderPanic((Creature) m, getDouble(g, "c"));
                 case "Perch" -> new PathfinderRideShoulder((Parrot) m);

--- a/1_19_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_19_R1.java
+++ b/1_19_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_19_R1.java
@@ -1158,13 +1158,18 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
     public static Sound fromNMS(SoundEvent s) { return CraftSound.getBukkit(s); }
 
     public static Mob getEntity(Goal g) {
+        // For no discernible reason, the Mob field in DoorInteractGoal
+        // is not final, unlike the mob fields in every other pathfinder.
+        // Since DoorInteractGoal and subclasses each only have one mob field,
+        // we can simply ignore the "final" check in this case.
+        boolean ignoreNonFinal = g instanceof DoorInteractGoal;
         try {
             Class<? extends Goal> clazz = g.getClass();
 
             while (clazz.getSuperclass() != null) {
                 for (Field f : clazz.getDeclaredFields()) {
                     f.setAccessible(true);
-                    if (net.minecraft.world.entity.Mob.class.isAssignableFrom(f.getType()) && Modifier.isFinal(f.getModifiers())) {
+                    if (net.minecraft.world.entity.Mob.class.isAssignableFrom(f.getType()) && (ignoreNonFinal || Modifier.isFinal(f.getModifiers()))) {
                         return fromNMS((net.minecraft.world.entity.Mob) f.get(g));
                     }
                 }
@@ -1172,7 +1177,6 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
                 if (Goal.class.isAssignableFrom(clazz.getSuperclass())) clazz = (Class<? extends Goal>) clazz.getSuperclass();
                 else break;
             }
-
             return null;
         } catch (Exception e) {
             Bukkit.getLogger().severe(e.getMessage());
@@ -1289,7 +1293,7 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
                 case "FollowParent" -> new PathfinderFollowParent((Animals) m, getDouble(g, "f"));
                 case "HorseTrap" -> new PathfinderSkeletonTrap((SkeletonHorse) m);
                 case "LeapAtTarget" -> new PathfinderLeapAtTarget(m, getFloat(g, "c"));
-                case "JumpOnBlock" -> new PathfinderCatOnBlock((Cat) m, getDouble(g, "g"));
+                case "JumpOnBlock" -> new PathfinderCatOnBlock((Cat) m, getDouble(g, "b"));
                 case "LlamaFollow" -> new PathfinderLlamaFollowCaravan((Llama) m, getDouble(g, "b"));
                 case "LookAtPlayer" -> new PathfinderLookAtEntity<>(m, fromNMS(getObject(g, "f", Class.class), LivingEntity.class), getFloat(g, "d"), getFloat(g, "e"), getBoolean(g, "i"));
                 case "LookAtTradingPlayer" -> new PathfinderLookAtTradingPlayer((AbstractVillager) m);
@@ -1300,7 +1304,7 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
                 case "Raid" -> new PathfinderMoveToRaid((Raider) m);
                 case "MoveTowardsRestriction" -> new PathfinderMoveTowardsRestriction((Creature) m, getDouble(g, "e"));
                 case "MoveTowardsTarget" -> new PathfinderMoveTowardsTarget((Creature) m, getDouble(g, "f"), getFloat(g, "g"));
-                case "OcelotAttack" -> new PathfinderOcelotAttack((Ocelot) m);
+                case "OcelotAttack" -> new PathfinderOcelotAttack(m);
                 case "OfferFlower" -> new PathfinderOfferFlower((IronGolem) m);
                 case "Panic" -> new PathfinderPanic((Creature) m, getDouble(g, "c"));
                 case "Perch" -> new PathfinderRideShoulder((Parrot) m);

--- a/1_19_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_19_R2.java
+++ b/1_19_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_19_R2.java
@@ -703,7 +703,7 @@ public final class ChipUtil1_19_R2 implements ChipUtil {
     public static DamageSource toNMS(EntityDamageEvent.DamageCause c, Entity en) {
         if (en != null) {
             net.minecraft.world.entity.Entity nmsEntity = toNMS(en);
-            
+
             if (c == EntityDamageEvent.DamageCause.FALLING_BLOCK)
               return DamageSource.fallingBlock(nmsEntity);
         }
@@ -729,7 +729,7 @@ public final class ChipUtil1_19_R2 implements ChipUtil {
             case DRYOUT -> DamageSource.DRY_OUT;
             default -> DamageSource.GENERIC;
         };
-    }   
+    }
 
     public static ItemEntity toNMS(org.bukkit.entity.Item i) {
         return (ItemEntity) ((CraftItem) i).getHandle();
@@ -1166,13 +1166,18 @@ public final class ChipUtil1_19_R2 implements ChipUtil {
     public static Sound fromNMS(SoundEvent s) { return CraftSound.getBukkit(s); }
 
     public static Mob getEntity(Goal g) {
+        // For no discernible reason, the Mob field in DoorInteractGoal
+        // is not final, unlike the mob fields in every other pathfinder.
+        // Since DoorInteractGoal and subclasses each only have one mob field,
+        // we can simply ignore the "final" check in this case.
+        boolean ignoreNonFinal = g instanceof DoorInteractGoal;
         try {
             Class<? extends Goal> clazz = g.getClass();
 
             while (clazz.getSuperclass() != null) {
                 for (Field f : clazz.getDeclaredFields()) {
                     f.setAccessible(true);
-                    if (net.minecraft.world.entity.Mob.class.isAssignableFrom(f.getType()) && Modifier.isFinal(f.getModifiers())) {
+                    if (net.minecraft.world.entity.Mob.class.isAssignableFrom(f.getType()) && (ignoreNonFinal || Modifier.isFinal(f.getModifiers()))) {
                         return fromNMS((net.minecraft.world.entity.Mob) f.get(g));
                     }
                 }
@@ -1180,7 +1185,7 @@ public final class ChipUtil1_19_R2 implements ChipUtil {
                 if (Goal.class.isAssignableFrom(clazz.getSuperclass())) clazz = (Class<? extends Goal>) clazz.getSuperclass();
                 else break;
             }
-
+            Bukkit.getLogger().severe("Failed to find entity field for " + g.getClass().getName());
             return null;
         } catch (Exception e) {
             Bukkit.getLogger().severe(e.getMessage());
@@ -1210,6 +1215,10 @@ public final class ChipUtil1_19_R2 implements ChipUtil {
         return g;
     }
 
+    /**
+     * A "custom" pathfinder is one not known to MobChip,
+     * NMS or otherwise. (Private NMS pathfinders will be "custom.")
+     */
     public static CustomPathfinder custom(Goal g) {
         return new CustomPathfinder(getEntity(g)) {
             @Override
@@ -1297,7 +1306,7 @@ public final class ChipUtil1_19_R2 implements ChipUtil {
                 case "FollowParent" -> new PathfinderFollowParent((Animals) m, getDouble(g, "f"));
                 case "HorseTrap" -> new PathfinderSkeletonTrap((SkeletonHorse) m);
                 case "LeapAtTarget" -> new PathfinderLeapAtTarget(m, getFloat(g, "c"));
-                case "JumpOnBlock" -> new PathfinderCatOnBlock((Cat) m, getDouble(g, "g"));
+                case "JumpOnBlock" -> new PathfinderCatOnBlock((Cat) m, getDouble(g, "b"));
                 case "LlamaFollow" -> new PathfinderLlamaFollowCaravan((Llama) m, getDouble(g, "b"));
                 case "LookAtPlayer" -> new PathfinderLookAtEntity<>(m, fromNMS(getObject(g, "f", Class.class), LivingEntity.class), getFloat(g, "d"), getFloat(g, "e"), getBoolean(g, "i"));
                 case "LookAtTradingPlayer" -> new PathfinderLookAtTradingPlayer((AbstractVillager) m);
@@ -1308,7 +1317,7 @@ public final class ChipUtil1_19_R2 implements ChipUtil {
                 case "Raid" -> new PathfinderMoveToRaid((Raider) m);
                 case "MoveTowardsRestriction" -> new PathfinderMoveTowardsRestriction((Creature) m, getDouble(g, "e"));
                 case "MoveTowardsTarget" -> new PathfinderMoveTowardsTarget((Creature) m, getDouble(g, "f"), getFloat(g, "g"));
-                case "OcelotAttack" -> new PathfinderOcelotAttack((Ocelot) m);
+                case "OcelotAttack" -> new PathfinderOcelotAttack(m);
                 case "OfferFlower" -> new PathfinderOfferFlower((IronGolem) m);
                 case "Panic" -> new PathfinderPanic((Creature) m, getDouble(g, "c"));
                 case "Perch" -> new PathfinderRideShoulder((Parrot) m);

--- a/1_19_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_19_R2.java
+++ b/1_19_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_19_R2.java
@@ -1185,7 +1185,6 @@ public final class ChipUtil1_19_R2 implements ChipUtil {
                 if (Goal.class.isAssignableFrom(clazz.getSuperclass())) clazz = (Class<? extends Goal>) clazz.getSuperclass();
                 else break;
             }
-            Bukkit.getLogger().severe("Failed to find entity field for " + g.getClass().getName());
             return null;
         } catch (Exception e) {
             Bukkit.getLogger().severe(e.getMessage());

--- a/base/src/main/java/me/gamercoder215/mobchip/ai/goal/PathfinderOcelotAttack.java
+++ b/base/src/main/java/me/gamercoder215/mobchip/ai/goal/PathfinderOcelotAttack.java
@@ -1,6 +1,6 @@
 package me.gamercoder215.mobchip.ai.goal;
 
-import org.bukkit.entity.Ocelot;
+import org.bukkit.entity.Mob;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -12,7 +12,7 @@ public final class PathfinderOcelotAttack extends Pathfinder {
      * Constructs a PathfinderOcelotAttack.
      * @param m Ocelot to use
      */
-    public PathfinderOcelotAttack(@NotNull Ocelot m) {
+    public PathfinderOcelotAttack(@NotNull Mob m) {
         super(m);
     }
 


### PR DESCRIPTION
## Info
This PR:
- Changes 1_14_R1 to target MC 1.14.4 as it is more widely used than 1.14.0
- Changes PathfinderOcelotAttack to accept any Mob as a parameter to match the NMS it's backed by
- Skips final field checking for PathfinderGoalDoorInteract because its Mob field is not final
- Fixes an issue with PathfinderCatOnBlock, where the speed field is incorrectly named.

## Details
The goal of this PR was to fix two errors from my MobChip-dependent plugin reported to me:
```
java.lang.NullPointerException: Cannot invoke "java.lang.Double.doubleValue()" because the return value of "be.isach.ultracosmetics.shaded.mobchip.abstraction.ChipUtil1_19_R2.getObject(net.minecraft.world.entity.ai.goal.PathfinderGoal, String, java.lang.Class)" is null
        at be.isach.ultracosmetics.shaded.mobchip.abstraction.ChipUtil1_19_R2.getDouble(ChipUtil1_19_R2.java:1123) ~[UltraCosmetics-3.0-DEV-b3b.jar:?]
        at be.isach.ultracosmetics.shaded.mobchip.abstraction.ChipUtil1_19_R2.fromNMS(ChipUtil1_19_R2.java:1300) ~[UltraCosmetics-3.0-DEV-b3b.jar:?]
        at be.isach.ultracosmetics.shaded.mobchip.abstraction.ChipUtil1_19_R2.lambda$getGoals$0(ChipUtil1_19_R2.java:144) ~[UltraCosmetics-3.0-DEV-b3b.jar:?]
        at java.lang.Iterable.forEach(Iterable.java:75) ~[?:?]
        at be.isach.ultracosmetics.shaded.mobchip.abstraction.ChipUtil1_19_R2.getGoals(ChipUtil1_19_R2.java:144) ~[UltraCosmetics-3.0-DEV-b3b.jar:?]
        at be.isach.ultracosmetics.shaded.mobchip.bukkit.BukkitAI.updateMap(BukkitAI.java:36) ~[UltraCosmetics-3.0-DEV-b3b.jar:?]
        at be.isach.ultracosmetics.shaded.mobchip.bukkit.BukkitAI.<init>(BukkitAI.java:31) ~[UltraCosmetics-3.0-DEV-b3b.jar:?]
        at be.isach.ultracosmetics.shaded.mobchip.bukkit.BukkitBrain.getGoalAI(BukkitBrain.java:101) ~[UltraCosmetics-3.0-DEV-b3b.jar:?]
        at be.isach.ultracosmetics.cosmetics.pets.Pet.clearPathfinders(Pet.java:137) ~[UltraCosmetics-3.0-DEV-b3b.jar:?]
...
```
```
java.lang.IllegalArgumentException: Entity cannot be null
        at be.isach.ultracosmetics.shaded.mobchip.ai.goal.Pathfinder.<init>(Pathfinder.java:24) ~[UltraCosmetics-3.0-DEV-b3b.jar:?]
        at be.isach.ultracosmetics.shaded.mobchip.ai.goal.CustomPathfinder.<init>(CustomPathfinder.java:16) ~[UltraCosmetics-3.0-DEV-b3b.jar:?]
        at be.isach.ultracosmetics.shaded.mobchip.abstraction.ChipUtil1_19_R2$3.<init>(ChipUtil1_19_R2.java:1214) ~[UltraCosmetics-3.0-DEV-b3b.jar:?]
        at be.isach.ultracosmetics.shaded.mobchip.abstraction.ChipUtil1_19_R2.custom(ChipUtil1_19_R2.java:1214) ~[UltraCosmetics-3.0-DEV-b3b.jar:?]
        at be.isach.ultracosmetics.shaded.mobchip.abstraction.ChipUtil1_19_R2.fromNMS(ChipUtil1_19_R2.java:1347) ~[UltraCosmetics-3.0-DEV-b3b.jar:?]
        at be.isach.ultracosmetics.shaded.mobchip.abstraction.ChipUtil1_19_R2.lambda$getGoals$0(ChipUtil1_19_R2.java:144) ~[UltraCosmetics-3.0-DEV-b3b.jar:?]
        at java.lang.Iterable.forEach(Iterable.java:75) ~[?:?]
        at be.isach.ultracosmetics.shaded.mobchip.abstraction.ChipUtil1_19_R2.getGoals(ChipUtil1_19_R2.java:144) ~[UltraCosmetics-3.0-DEV-b3b.jar:?]
        at be.isach.ultracosmetics.shaded.mobchip.bukkit.BukkitAI.updateMap(BukkitAI.java:36) ~[UltraCosmetics-3.0-DEV-b3b.jar:?]
        at be.isach.ultracosmetics.shaded.mobchip.bukkit.BukkitAI.<init>(BukkitAI.java:31) ~[UltraCosmetics-3.0-DEV-b3b.jar:?]
        at be.isach.ultracosmetics.shaded.mobchip.bukkit.BukkitBrain.getGoalAI(BukkitBrain.java:101) ~[UltraCosmetics-3.0-DEV-b3b.jar:?]
        at be.isach.ultracosmetics.cosmetics.pets.Pet.clearPathfinders(Pet.java:137) ~[UltraCosmetics-3.0-DEV-b3b.jar:?]
...
```
The primary cause of the first one was that the speed field was written as `g` in the code, which is the field for the ocelot itself, not the speed, which appears to be `b`. In testing this fix, I ran into a second error about casting, which is the reason for the change to PathfinderOcelotAttack.

The cause of the second one was that the code that scans for Mob fields in the pathfinders ignores any non-final fields, which is usually perfect for determining the target of the pathfinder. But, for some unclear reason, the Mob field in `PathfinderGoalDoorInteract` is not final, so the code was unable to find the field. I've resolved this by skipping the check for whether the field is final as long as the pathfinder is a descendant of `PathfinderGoalDoorInteract`, since its current subclasses have no other Mob fields.
## Tested Environments

### OS
OS: Debian 11

### Java / Minecraft

#### MC Builds
- [ ] Tested on Latest Spigot Version
- [X] Tested on Latest Paper / Purpur Version

Also tested on 1.14.4.

#### JDK Builds
Tested on:
- [X] JDK Version 8/11
- [X] JDK Version 17/18

It seems further development is needed to run without errors on 1.13, but this was the case before the PR as well, and the errors are non-fatal. Here's an example of one I encountered:

```
[00:17:58 ERROR]: Entity cannot be null
[00:17:58 ERROR]: be.isach.ultracosmetics.shaded.mobchip.ai.goal.Pathfinder.<init>(Pathfinder.java:24)
[00:17:58 ERROR]: be.isach.ultracosmetics.shaded.mobchip.ai.goal.PathfinderMeleeAttack.<init>(PathfinderMeleeAttack.java:46)
[00:17:58 ERROR]: be.isach.ultracosmetics.shaded.mobchip.abstraction.ChipUtil1_13_R2.fromNMS(ChipUtil1_13_R2.java:881)
[00:17:58 ERROR]: be.isach.ultracosmetics.shaded.mobchip.abstraction.ChipUtil1_13_R2.getGoals(ChipUtil1_13_R2.java:84)
[00:17:58 ERROR]: be.isach.ultracosmetics.shaded.mobchip.abstraction.ChipUtil.clearPathfinders(ChipUtil.java:52)
[00:17:58 ERROR]: be.isach.ultracosmetics.shaded.mobchip.bukkit.BukkitAI.updateAI(BukkitAI.java:42)
[00:17:58 ERROR]: be.isach.ultracosmetics.shaded.mobchip.bukkit.BukkitAI.add(BukkitAI.java:118)
[00:17:58 ERROR]: be.isach.ultracosmetics.shaded.mobchip.bukkit.BukkitAI.put(BukkitAI.java:75)
[00:17:58 ERROR]: be.isach.ultracosmetics.cosmetics.pets.Pet.clearPathfinders(Pet.java:141)
...
```

## Demonstration
*Note the distinct lack of console errors here* 😉 
