### PR TITLE
Better stack traces

### DIFF
--- a/1_13_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R1.java
+++ b/1_13_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R1.java
@@ -649,8 +649,7 @@ public final class ChipUtil1_13_R1 implements ChipUtil {
             }
             return null;
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -761,8 +760,7 @@ public final class ChipUtil1_13_R1 implements ChipUtil {
                 }
             }
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
 
         return null;
@@ -807,8 +805,7 @@ public final class ChipUtil1_13_R1 implements ChipUtil {
 
             return m.invoke(g, args);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1005,9 +1002,7 @@ public final class ChipUtil1_13_R1 implements ChipUtil {
             healthF.setAccessible(true);
             health = healthF.getFloat(en);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
 
         return new me.gamercoder215.mobchip.combat.CombatEntry(m, fromNMS(en.a()), time, health, en.c(), en.g() == null ? null : CombatLocation.getByKey(NamespacedKey.minecraft(en.g())), en.j(), en.a().getEntity() == null ? null : fromNMS(en.a().getEntity()));
@@ -1029,9 +1024,7 @@ public final class ChipUtil1_13_R1 implements ChipUtil {
             m.setAccessible(true);
             m.invoke(nmsMob, list.stream().map(ChipUtil1_13_R1::toNMS).collect(Collectors.toList()));
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 

--- a/1_13_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_13_R1/EntityCombatTracker1_13_R1.java
+++ b/1_13_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_13_R1/EntityCombatTracker1_13_R1.java
@@ -1,10 +1,10 @@
 package me.gamercoder215.mobchip.abstraction.v1_13_R1;
 
+import me.gamercoder215.mobchip.abstraction.ChipUtil;
 import me.gamercoder215.mobchip.abstraction.ChipUtil1_13_R1;
 import me.gamercoder215.mobchip.combat.CombatEntry;
 import me.gamercoder215.mobchip.combat.EntityCombatTracker;
 import net.minecraft.server.v1_13_R1.CombatTracker;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Mob;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -44,9 +44,7 @@ public class EntityCombatTracker1_13_R1 implements EntityCombatTracker {
             f.setAccessible(true);
             ((List<net.minecraft.server.v1_13_R1.CombatEntry>) f.get(handle)).stream().map(en -> ChipUtil1_13_R1.fromNMS(m, en)).forEach(entries::add);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return entries;
     }
@@ -62,9 +60,7 @@ public class EntityCombatTracker1_13_R1 implements EntityCombatTracker {
             Method m = List.class.getMethod("add", Object.class);
             m.invoke(entries, ChipUtil1_13_R1.toNMS(entry));
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 
@@ -81,9 +77,7 @@ public class EntityCombatTracker1_13_R1 implements EntityCombatTracker {
             damage.setAccessible(true);
             return damage.getBoolean(handle);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return false;
     }
@@ -96,9 +90,7 @@ public class EntityCombatTracker1_13_R1 implements EntityCombatTracker {
             combat.setAccessible(true);
             return combat.getBoolean(handle);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return false;
     }

--- a/1_13_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_13_R1/NavigationPath1_13_R1.java
+++ b/1_13_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_13_R1/NavigationPath1_13_R1.java
@@ -1,10 +1,10 @@
 package me.gamercoder215.mobchip.abstraction.v1_13_R1;
 
+import me.gamercoder215.mobchip.abstraction.ChipUtil;
 import me.gamercoder215.mobchip.ai.navigation.NavigationPath;
 import me.gamercoder215.mobchip.util.Position;
 import net.minecraft.server.v1_13_R1.PathEntity;
 import net.minecraft.server.v1_13_R1.PathPoint;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Mob;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -42,8 +42,7 @@ public final class NavigationPath1_13_R1 implements NavigationPath {
             PathPoint n = pathPoints[handle.e()];
             new EntityController1_13_R1(m).moveTo(n.a, n.b, n.c);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 

--- a/1_13_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R2.java
+++ b/1_13_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_13_R2.java
@@ -730,8 +730,7 @@ public class ChipUtil1_13_R2 implements ChipUtil {
                 }
             }
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
 
         return null;
@@ -807,8 +806,7 @@ public class ChipUtil1_13_R2 implements ChipUtil {
             }
             return null;
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -820,8 +818,7 @@ public class ChipUtil1_13_R2 implements ChipUtil {
 
             return m.invoke(g, args);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1010,9 +1007,7 @@ public class ChipUtil1_13_R2 implements ChipUtil {
             healthF.setAccessible(true);
             health = healthF.getFloat(en);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
 
         return new me.gamercoder215.mobchip.combat.CombatEntry(m, fromNMS(en.a()), time, health, en.c(), en.g() == null ? null : CombatLocation.getByKey(NamespacedKey.minecraft(en.g())), en.j(), en.a().getEntity() == null ? null : fromNMS(en.a().getEntity()));
@@ -1034,9 +1029,7 @@ public class ChipUtil1_13_R2 implements ChipUtil {
             m.setAccessible(true);
             m.invoke(nmsMob, list.stream().map(ChipUtil1_13_R2::toNMS).collect(Collectors.toList()));
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 

--- a/1_13_R2/src/main/java/me/gamercoder215/mobchip/abstraction/v1_13_R2/EntityCombatTracker1_13_R2.java
+++ b/1_13_R2/src/main/java/me/gamercoder215/mobchip/abstraction/v1_13_R2/EntityCombatTracker1_13_R2.java
@@ -1,10 +1,10 @@
 package me.gamercoder215.mobchip.abstraction.v1_13_R2;
 
+import me.gamercoder215.mobchip.abstraction.ChipUtil;
 import me.gamercoder215.mobchip.abstraction.ChipUtil1_13_R2;
 import me.gamercoder215.mobchip.combat.CombatEntry;
 import me.gamercoder215.mobchip.combat.EntityCombatTracker;
 import net.minecraft.server.v1_13_R2.CombatTracker;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Mob;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -44,9 +44,7 @@ public class EntityCombatTracker1_13_R2 implements EntityCombatTracker {
             f.setAccessible(true);
             ((List<net.minecraft.server.v1_13_R2.CombatEntry>) f.get(handle)).stream().map(en -> ChipUtil1_13_R2.fromNMS(m, en)).forEach(entries::add);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return entries;
     }
@@ -62,9 +60,7 @@ public class EntityCombatTracker1_13_R2 implements EntityCombatTracker {
             Method m = List.class.getMethod("add", Object.class);
             m.invoke(entries, ChipUtil1_13_R2.toNMS(entry));
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 
@@ -81,9 +77,7 @@ public class EntityCombatTracker1_13_R2 implements EntityCombatTracker {
             damage.setAccessible(true);
             return damage.getBoolean(handle);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return false;
     }
@@ -96,9 +90,7 @@ public class EntityCombatTracker1_13_R2 implements EntityCombatTracker {
             combat.setAccessible(true);
             return combat.getBoolean(handle);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return false;
     }

--- a/1_13_R2/src/main/java/me/gamercoder215/mobchip/abstraction/v1_13_R2/NavigationPath1_13_R2.java
+++ b/1_13_R2/src/main/java/me/gamercoder215/mobchip/abstraction/v1_13_R2/NavigationPath1_13_R2.java
@@ -1,10 +1,10 @@
 package me.gamercoder215.mobchip.abstraction.v1_13_R2;
 
+import me.gamercoder215.mobchip.abstraction.ChipUtil;
 import me.gamercoder215.mobchip.ai.navigation.NavigationPath;
 import me.gamercoder215.mobchip.util.Position;
 import net.minecraft.server.v1_13_R2.PathEntity;
 import net.minecraft.server.v1_13_R2.PathPoint;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Mob;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -42,8 +42,7 @@ public final class NavigationPath1_13_R2 implements NavigationPath {
             PathPoint n = pathPoints[handle.e()];
             new EntityController1_13_R2(m).moveTo(n.a, n.b, n.c);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 

--- a/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_14_R1.java
+++ b/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_14_R1.java
@@ -432,8 +432,7 @@ public class ChipUtil1_14_R1 implements ChipUtil {
             Behavior<? super EntityLiving> b = (Behavior<? super EntityLiving>) c.newInstance(args);
             return new BehaviorResult1_14_R1(b, nms);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -514,9 +513,7 @@ public class ChipUtil1_14_R1 implements ChipUtil {
             Set<Activity> activities = (Set<Activity>) active.get(nmsMob.getBehaviorController());
             return activities.stream().map(ChipUtil1_14_R1::fromNMS).collect(Collectors.toSet());
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
 
         return Collections.emptySet();
@@ -1010,8 +1007,7 @@ public class ChipUtil1_14_R1 implements ChipUtil {
                 }
             }
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
 
         return null;
@@ -1073,8 +1069,7 @@ public class ChipUtil1_14_R1 implements ChipUtil {
             }
             return null;
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1086,8 +1081,7 @@ public class ChipUtil1_14_R1 implements ChipUtil {
 
             return m.invoke(g, args);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1284,9 +1278,7 @@ public class ChipUtil1_14_R1 implements ChipUtil {
             healthF.setAccessible(true);
             health = healthF.getFloat(en);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
 
         return new me.gamercoder215.mobchip.combat.CombatEntry(m, fromNMS(en.a()), time, health, en.c(), en.g() == null ? null : CombatLocation.getByKey(NamespacedKey.minecraft(en.g())), en.j(), en.a().getEntity() == null ? null : fromNMS(en.a().getEntity()));
@@ -1308,9 +1300,7 @@ public class ChipUtil1_14_R1 implements ChipUtil {
             m.setAccessible(true);
             m.invoke(nmsMob, list.stream().map(ChipUtil1_14_R1::toNMS).collect(Collectors.toList()));
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 

--- a/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_14_R1/EntityCombatTracker1_14_R1.java
+++ b/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_14_R1/EntityCombatTracker1_14_R1.java
@@ -1,10 +1,10 @@
 package me.gamercoder215.mobchip.abstraction.v1_14_R1;
 
+import me.gamercoder215.mobchip.abstraction.ChipUtil;
 import me.gamercoder215.mobchip.abstraction.ChipUtil1_14_R1;
 import me.gamercoder215.mobchip.combat.CombatEntry;
 import me.gamercoder215.mobchip.combat.EntityCombatTracker;
 import net.minecraft.server.v1_14_R1.CombatTracker;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Mob;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -44,9 +44,7 @@ public class EntityCombatTracker1_14_R1 implements EntityCombatTracker {
             f.setAccessible(true);
             ((List<net.minecraft.server.v1_14_R1.CombatEntry>) f.get(handle)).stream().map(en -> ChipUtil1_14_R1.fromNMS(m, en)).forEach(entries::add);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return entries;
     }
@@ -62,9 +60,7 @@ public class EntityCombatTracker1_14_R1 implements EntityCombatTracker {
             Method m = List.class.getMethod("add", Object.class);
             m.invoke(entries, ChipUtil1_14_R1.toNMS(entry));
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 
@@ -81,9 +77,7 @@ public class EntityCombatTracker1_14_R1 implements EntityCombatTracker {
             damage.setAccessible(true);
             return damage.getBoolean(handle);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return false;
     }
@@ -96,9 +90,7 @@ public class EntityCombatTracker1_14_R1 implements EntityCombatTracker {
             combat.setAccessible(true);
             return combat.getBoolean(handle);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return false;
     }

--- a/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_14_R1/EntityGossipContainer1_14_R1.java
+++ b/1_14_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_14_R1/EntityGossipContainer1_14_R1.java
@@ -1,12 +1,12 @@
 package me.gamercoder215.mobchip.abstraction.v1_14_R1;
 
+import me.gamercoder215.mobchip.abstraction.ChipUtil;
 import me.gamercoder215.mobchip.abstraction.ChipUtil1_14_R1;
 import me.gamercoder215.mobchip.ai.gossip.EntityGossipContainer;
 import me.gamercoder215.mobchip.ai.gossip.GossipType;
 import net.minecraft.server.v1_14_R1.EntityVillager;
 import net.minecraft.server.v1_14_R1.Reputation;
 import net.minecraft.server.v1_14_R1.ReputationType;
-import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.libs.it.unimi.dsi.fastutil.objects.Object2IntMap;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftVillager;
 import org.bukkit.entity.Entity;
@@ -34,9 +34,7 @@ public class EntityGossipContainer1_14_R1 implements EntityGossipContainer {
             containerF.setAccessible(true);
             handle = (Reputation) containerF.get(((CraftVillager) v).getHandle());
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 
@@ -66,9 +64,7 @@ public class EntityGossipContainer1_14_R1 implements EntityGossipContainer {
                 reputationsF.set(o, reputations);
             }
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 
@@ -91,9 +87,7 @@ public class EntityGossipContainer1_14_R1 implements EntityGossipContainer {
             data.remove(en.getUniqueId());
             map.set(handle, data);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 
@@ -117,9 +111,7 @@ public class EntityGossipContainer1_14_R1 implements EntityGossipContainer {
             }
             map.set(handle, data);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 }

--- a/1_15_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_15_R1.java
+++ b/1_15_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_15_R1.java
@@ -433,8 +433,7 @@ public class ChipUtil1_15_R1 implements ChipUtil {
             Behavior<? super EntityLiving> b = (Behavior<? super EntityLiving>) c.newInstance(args);
             return new BehaviorResult1_15_R1(b, nms);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -514,9 +513,7 @@ public class ChipUtil1_15_R1 implements ChipUtil {
             Set<Activity> activities = (Set<Activity>) active.get(nmsMob.getBehaviorController());
             return activities.stream().map(ChipUtil1_15_R1::fromNMS).collect(Collectors.toSet());
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
 
         return Collections.emptySet();
@@ -1009,8 +1006,7 @@ public class ChipUtil1_15_R1 implements ChipUtil {
                 }
             }
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
 
         return null;
@@ -1072,8 +1068,7 @@ public class ChipUtil1_15_R1 implements ChipUtil {
             }
             return null;
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1085,8 +1080,7 @@ public class ChipUtil1_15_R1 implements ChipUtil {
 
             return m.invoke(g, args);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1284,9 +1278,7 @@ public class ChipUtil1_15_R1 implements ChipUtil {
             healthF.setAccessible(true);
             health = healthF.getFloat(en);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
 
         return new me.gamercoder215.mobchip.combat.CombatEntry(m, fromNMS(en.a()), time, health, en.c(), en.g() == null ? null : CombatLocation.getByKey(NamespacedKey.minecraft(en.g())), en.j(), en.a().getEntity() == null ? null : fromNMS(en.a().getEntity()));
@@ -1308,9 +1300,7 @@ public class ChipUtil1_15_R1 implements ChipUtil {
             m.setAccessible(true);
             m.invoke(nmsMob, list.stream().map(ChipUtil1_15_R1::toNMS).collect(Collectors.toList()));
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 

--- a/1_15_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_15_R1/EntityCombatTracker1_15_R1.java
+++ b/1_15_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_15_R1/EntityCombatTracker1_15_R1.java
@@ -1,10 +1,10 @@
 package me.gamercoder215.mobchip.abstraction.v1_15_R1;
 
+import me.gamercoder215.mobchip.abstraction.ChipUtil;
 import me.gamercoder215.mobchip.abstraction.ChipUtil1_15_R1;
 import me.gamercoder215.mobchip.combat.CombatEntry;
 import me.gamercoder215.mobchip.combat.EntityCombatTracker;
 import net.minecraft.server.v1_15_R1.CombatTracker;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Mob;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -44,9 +44,7 @@ public class EntityCombatTracker1_15_R1 implements EntityCombatTracker {
             f.setAccessible(true);
             ((List<net.minecraft.server.v1_15_R1.CombatEntry>) f.get(handle)).stream().map(en -> ChipUtil1_15_R1.fromNMS(m, en)).forEach(entries::add);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return entries;
     }
@@ -62,9 +60,7 @@ public class EntityCombatTracker1_15_R1 implements EntityCombatTracker {
             Method m = List.class.getMethod("add", Object.class);
             m.invoke(entries, ChipUtil1_15_R1.toNMS(entry));
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 
@@ -81,9 +77,7 @@ public class EntityCombatTracker1_15_R1 implements EntityCombatTracker {
             damage.setAccessible(true);
             return damage.getBoolean(handle);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return false;
     }
@@ -96,9 +90,7 @@ public class EntityCombatTracker1_15_R1 implements EntityCombatTracker {
             combat.setAccessible(true);
             return combat.getBoolean(handle);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return false;
     }

--- a/1_15_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_15_R1/EntityGossipContainer1_15_R1.java
+++ b/1_15_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_15_R1/EntityGossipContainer1_15_R1.java
@@ -1,11 +1,11 @@
 package me.gamercoder215.mobchip.abstraction.v1_15_R1;
 
+import me.gamercoder215.mobchip.abstraction.ChipUtil;
 import me.gamercoder215.mobchip.abstraction.ChipUtil1_15_R1;
 import me.gamercoder215.mobchip.ai.gossip.EntityGossipContainer;
 import me.gamercoder215.mobchip.ai.gossip.GossipType;
 import net.minecraft.server.v1_15_R1.Reputation;
 import net.minecraft.server.v1_15_R1.ReputationType;
-import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftVillager;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Villager;
@@ -58,9 +58,7 @@ public class EntityGossipContainer1_15_R1 implements EntityGossipContainer {
             data.remove(en.getUniqueId());
             map.set(handle, data);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 
@@ -84,9 +82,7 @@ public class EntityGossipContainer1_15_R1 implements EntityGossipContainer {
             }
             map.set(handle, data);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 }

--- a/1_16_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R1.java
+++ b/1_16_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R1.java
@@ -472,8 +472,7 @@ public class ChipUtil1_16_R1 implements ChipUtil {
             Behavior<? super EntityLiving> b = (Behavior<? super EntityLiving>) c.newInstance(args);
             return new BehaviorResult1_16_R1(b, nms);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -540,9 +539,7 @@ public class ChipUtil1_16_R1 implements ChipUtil {
             Set<Activity> activities = (Set<Activity>) active.get(nmsMob.getBehaviorController());
             return activities.stream().map(ChipUtil1_16_R1::fromNMS).collect(Collectors.toSet());
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
 
         return Collections.emptySet();
@@ -1034,8 +1031,7 @@ public class ChipUtil1_16_R1 implements ChipUtil {
                 }
             }
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
 
         return null;
@@ -1097,8 +1093,7 @@ public class ChipUtil1_16_R1 implements ChipUtil {
             }
             return null;
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1110,8 +1105,7 @@ public class ChipUtil1_16_R1 implements ChipUtil {
 
             return m.invoke(g, args);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1320,9 +1314,7 @@ public class ChipUtil1_16_R1 implements ChipUtil {
             healthF.setAccessible(true);
             health = healthF.getFloat(en);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
 
         return new me.gamercoder215.mobchip.combat.CombatEntry(m, fromNMS(en.a()), time, health, en.c(), en.g() == null ? null : CombatLocation.getByKey(NamespacedKey.minecraft(en.g())), en.j(), en.a().getEntity() == null ? null : fromNMS(en.a().getEntity()));
@@ -1344,9 +1336,7 @@ public class ChipUtil1_16_R1 implements ChipUtil {
             m.setAccessible(true);
             m.invoke(nmsMob, list.stream().map(ChipUtil1_16_R1::toNMS).collect(Collectors.toList()));
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 

--- a/1_16_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_16_R1/EntityCombatTracker1_16_R1.java
+++ b/1_16_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_16_R1/EntityCombatTracker1_16_R1.java
@@ -1,10 +1,10 @@
 package me.gamercoder215.mobchip.abstraction.v1_16_R1;
 
+import me.gamercoder215.mobchip.abstraction.ChipUtil;
 import me.gamercoder215.mobchip.abstraction.ChipUtil1_16_R1;
 import me.gamercoder215.mobchip.combat.CombatEntry;
 import me.gamercoder215.mobchip.combat.EntityCombatTracker;
 import net.minecraft.server.v1_16_R1.CombatTracker;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Mob;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -44,9 +44,7 @@ public class EntityCombatTracker1_16_R1 implements EntityCombatTracker {
             f.setAccessible(true);
             ((List<net.minecraft.server.v1_16_R1.CombatEntry>) f.get(handle)).stream().map(en -> ChipUtil1_16_R1.fromNMS(m, en)).forEach(entries::add);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return entries;
     }
@@ -62,9 +60,7 @@ public class EntityCombatTracker1_16_R1 implements EntityCombatTracker {
             Method m = List.class.getMethod("add", Object.class);
             m.invoke(entries, ChipUtil1_16_R1.toNMS(entry));
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 
@@ -81,9 +77,7 @@ public class EntityCombatTracker1_16_R1 implements EntityCombatTracker {
             damage.setAccessible(true);
             return damage.getBoolean(handle);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return false;
     }
@@ -96,9 +90,7 @@ public class EntityCombatTracker1_16_R1 implements EntityCombatTracker {
             combat.setAccessible(true);
             return combat.getBoolean(handle);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return false;
     }

--- a/1_16_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_16_R1/EntityGossipContainer1_16_R1.java
+++ b/1_16_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_16_R1/EntityGossipContainer1_16_R1.java
@@ -1,11 +1,11 @@
 package me.gamercoder215.mobchip.abstraction.v1_16_R1;
 
+import me.gamercoder215.mobchip.abstraction.ChipUtil;
 import me.gamercoder215.mobchip.abstraction.ChipUtil1_16_R1;
 import me.gamercoder215.mobchip.ai.gossip.EntityGossipContainer;
 import me.gamercoder215.mobchip.ai.gossip.GossipType;
 import net.minecraft.server.v1_16_R1.Reputation;
 import net.minecraft.server.v1_16_R1.ReputationType;
-import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftVillager;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Villager;
@@ -58,9 +58,7 @@ public class EntityGossipContainer1_16_R1 implements EntityGossipContainer {
             data.remove(en.getUniqueId());
             map.set(handle, data);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 
@@ -84,9 +82,7 @@ public class EntityGossipContainer1_16_R1 implements EntityGossipContainer {
             }
             map.set(handle, data);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 }

--- a/1_16_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R2.java
+++ b/1_16_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R2.java
@@ -432,8 +432,7 @@ public class ChipUtil1_16_R2 implements ChipUtil {
             Behavior<? super EntityLiving> b = (Behavior<? super EntityLiving>) c.newInstance(args);
             return new BehaviorResult1_16_R2(b, nms);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -538,9 +537,7 @@ public class ChipUtil1_16_R2 implements ChipUtil {
             Set<Activity> activities = (Set<Activity>) active.get(nmsMob.getBehaviorController());
             return activities.stream().map(ChipUtil1_16_R2::fromNMS).collect(Collectors.toSet());
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
 
         return Collections.emptySet();
@@ -1030,8 +1027,7 @@ public class ChipUtil1_16_R2 implements ChipUtil {
                 }
             }
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
 
         return null;
@@ -1093,8 +1089,7 @@ public class ChipUtil1_16_R2 implements ChipUtil {
             }
             return null;
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1106,8 +1101,7 @@ public class ChipUtil1_16_R2 implements ChipUtil {
 
             return m.invoke(g, args);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1316,9 +1310,7 @@ public class ChipUtil1_16_R2 implements ChipUtil {
             healthF.setAccessible(true);
             health = healthF.getFloat(en);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
 
         return new me.gamercoder215.mobchip.combat.CombatEntry(m, fromNMS(en.a()), time, health, en.c(), en.g() == null ? null : CombatLocation.getByKey(NamespacedKey.minecraft(en.g())), en.j(), en.a().getEntity() == null ? null : fromNMS(en.a().getEntity()));
@@ -1340,9 +1332,7 @@ public class ChipUtil1_16_R2 implements ChipUtil {
             m.setAccessible(true);
             m.invoke(nmsMob, list.stream().map(ChipUtil1_16_R2::toNMS).collect(Collectors.toList()));
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 

--- a/1_16_R2/src/main/java/me/gamercoder215/mobchip/abstraction/v1_16_R2/EntityCombatTracker1_16_R2.java
+++ b/1_16_R2/src/main/java/me/gamercoder215/mobchip/abstraction/v1_16_R2/EntityCombatTracker1_16_R2.java
@@ -1,10 +1,10 @@
 package me.gamercoder215.mobchip.abstraction.v1_16_R2;
 
+import me.gamercoder215.mobchip.abstraction.ChipUtil;
 import me.gamercoder215.mobchip.abstraction.ChipUtil1_16_R2;
 import me.gamercoder215.mobchip.combat.CombatEntry;
 import me.gamercoder215.mobchip.combat.EntityCombatTracker;
 import net.minecraft.server.v1_16_R2.CombatTracker;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Mob;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -44,9 +44,7 @@ public class EntityCombatTracker1_16_R2 implements EntityCombatTracker {
             f.setAccessible(true);
             ((List<net.minecraft.server.v1_16_R2.CombatEntry>) f.get(handle)).stream().map(en -> ChipUtil1_16_R2.fromNMS(m, en)).forEach(entries::add);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return entries;
     }
@@ -62,9 +60,7 @@ public class EntityCombatTracker1_16_R2 implements EntityCombatTracker {
             Method m = List.class.getMethod("add", Object.class);
             m.invoke(entries, ChipUtil1_16_R2.toNMS(entry));
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 
@@ -81,9 +77,7 @@ public class EntityCombatTracker1_16_R2 implements EntityCombatTracker {
             damage.setAccessible(true);
             return damage.getBoolean(handle);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return false;
     }
@@ -96,9 +90,7 @@ public class EntityCombatTracker1_16_R2 implements EntityCombatTracker {
             combat.setAccessible(true);
             return combat.getBoolean(handle);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return false;
     }

--- a/1_16_R2/src/main/java/me/gamercoder215/mobchip/abstraction/v1_16_R2/EntityGossipContainer1_16_R2.java
+++ b/1_16_R2/src/main/java/me/gamercoder215/mobchip/abstraction/v1_16_R2/EntityGossipContainer1_16_R2.java
@@ -1,11 +1,11 @@
 package me.gamercoder215.mobchip.abstraction.v1_16_R2;
 
+import me.gamercoder215.mobchip.abstraction.ChipUtil;
 import me.gamercoder215.mobchip.abstraction.ChipUtil1_16_R2;
 import me.gamercoder215.mobchip.ai.gossip.EntityGossipContainer;
 import me.gamercoder215.mobchip.ai.gossip.GossipType;
 import net.minecraft.server.v1_16_R2.Reputation;
 import net.minecraft.server.v1_16_R2.ReputationType;
-import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_16_R2.entity.CraftVillager;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Villager;
@@ -58,9 +58,7 @@ public class EntityGossipContainer1_16_R2 implements EntityGossipContainer {
             data.remove(en.getUniqueId());
             map.set(handle, data);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 
@@ -84,9 +82,7 @@ public class EntityGossipContainer1_16_R2 implements EntityGossipContainer {
             }
             map.set(handle, data);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 }

--- a/1_16_R3/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R3.java
+++ b/1_16_R3/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_16_R3.java
@@ -432,8 +432,7 @@ public class ChipUtil1_16_R3 implements ChipUtil {
             Behavior<? super EntityLiving> b = (Behavior<? super EntityLiving>) c.newInstance(args);
             return new BehaviorResult1_16_R3(b, nms);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -500,9 +499,7 @@ public class ChipUtil1_16_R3 implements ChipUtil {
             Set<Activity> activities = (Set<Activity>) active.get(nmsMob.getBehaviorController());
             return activities.stream().map(ChipUtil1_16_R3::fromNMS).collect(Collectors.toSet());
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
 
         return Collections.emptySet();
@@ -1031,8 +1028,7 @@ public class ChipUtil1_16_R3 implements ChipUtil {
                 }
             }
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
 
         return null;
@@ -1075,8 +1071,7 @@ public class ChipUtil1_16_R3 implements ChipUtil {
             }
             return null;
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1088,8 +1083,7 @@ public class ChipUtil1_16_R3 implements ChipUtil {
 
             return m.invoke(g, args);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1298,9 +1292,7 @@ public class ChipUtil1_16_R3 implements ChipUtil {
             healthF.setAccessible(true);
             health = healthF.getFloat(en);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
 
         return new CombatEntry(m, fromNMS(en.a()), time, health, en.c(), en.g() == null ? null : CombatLocation.getByKey(NamespacedKey.minecraft(en.g())), en.j(), en.a().getEntity() == null ? null : fromNMS(en.a().getEntity()));
@@ -1322,9 +1314,7 @@ public class ChipUtil1_16_R3 implements ChipUtil {
             m.setAccessible(true);
             m.invoke(nmsMob, list.stream().map(ChipUtil1_16_R3::toNMS).collect(Collectors.toList()));
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 

--- a/1_16_R3/src/main/java/me/gamercoder215/mobchip/abstraction/v1_16_R3/EntityCombatTracker1_16_R3.java
+++ b/1_16_R3/src/main/java/me/gamercoder215/mobchip/abstraction/v1_16_R3/EntityCombatTracker1_16_R3.java
@@ -1,10 +1,10 @@
 package me.gamercoder215.mobchip.abstraction.v1_16_R3;
 
+import me.gamercoder215.mobchip.abstraction.ChipUtil;
 import me.gamercoder215.mobchip.abstraction.ChipUtil1_16_R3;
 import me.gamercoder215.mobchip.combat.CombatEntry;
 import me.gamercoder215.mobchip.combat.EntityCombatTracker;
 import net.minecraft.server.v1_16_R3.CombatTracker;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Mob;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -44,9 +44,7 @@ public class EntityCombatTracker1_16_R3 implements EntityCombatTracker {
             f.setAccessible(true);
             ((List<net.minecraft.server.v1_16_R3.CombatEntry>) f.get(handle)).stream().map(en -> ChipUtil1_16_R3.fromNMS(m, en)).forEach(entries::add);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return entries;
     }
@@ -62,9 +60,7 @@ public class EntityCombatTracker1_16_R3 implements EntityCombatTracker {
             Method m = List.class.getMethod("add", Object.class);
             m.invoke(entries, ChipUtil1_16_R3.toNMS(entry));
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 
@@ -81,9 +77,7 @@ public class EntityCombatTracker1_16_R3 implements EntityCombatTracker {
             damage.setAccessible(true);
             return damage.getBoolean(handle);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return false;
     }
@@ -96,9 +90,7 @@ public class EntityCombatTracker1_16_R3 implements EntityCombatTracker {
             combat.setAccessible(true);
             return combat.getBoolean(handle);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return false;
     }

--- a/1_16_R3/src/main/java/me/gamercoder215/mobchip/abstraction/v1_16_R3/EntityGossipContainer1_16_R3.java
+++ b/1_16_R3/src/main/java/me/gamercoder215/mobchip/abstraction/v1_16_R3/EntityGossipContainer1_16_R3.java
@@ -1,11 +1,11 @@
 package me.gamercoder215.mobchip.abstraction.v1_16_R3;
 
+import me.gamercoder215.mobchip.abstraction.ChipUtil;
 import me.gamercoder215.mobchip.abstraction.ChipUtil1_16_R3;
 import me.gamercoder215.mobchip.ai.gossip.EntityGossipContainer;
 import me.gamercoder215.mobchip.ai.gossip.GossipType;
 import net.minecraft.server.v1_16_R3.Reputation;
 import net.minecraft.server.v1_16_R3.ReputationType;
-import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftVillager;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Villager;
@@ -58,9 +58,7 @@ public class EntityGossipContainer1_16_R3 implements EntityGossipContainer {
             data.remove(en.getUniqueId());
             map.set(handle, data);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 
@@ -84,9 +82,7 @@ public class EntityGossipContainer1_16_R3 implements EntityGossipContainer {
             }
             map.set(handle, data);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 }

--- a/1_17_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_17_R1.java
+++ b/1_17_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_17_R1.java
@@ -547,8 +547,7 @@ public final class ChipUtil1_17_R1 implements ChipUtil {
             Behavior<? super EntityLiving> b = (Behavior<? super EntityLiving>) c.newInstance(args);
             return new BehaviorResult1_17_R1(b, nms);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1118,8 +1117,7 @@ public final class ChipUtil1_17_R1 implements ChipUtil {
                 }
             }
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
 
         return null;
@@ -1159,8 +1157,7 @@ public final class ChipUtil1_17_R1 implements ChipUtil {
             }
             return null;
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1172,8 +1169,7 @@ public final class ChipUtil1_17_R1 implements ChipUtil {
 
             return m.invoke(g, args);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1390,9 +1386,7 @@ public final class ChipUtil1_17_R1 implements ChipUtil {
             m.setAccessible(true);
             m.invoke(nmsMob, list.stream().map(ChipUtil1_17_R1::toNMS).collect(Collectors.toList()));
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 

--- a/1_17_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_17_R1/EntityCombatTracker1_17_R1.java
+++ b/1_17_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_17_R1/EntityCombatTracker1_17_R1.java
@@ -1,10 +1,10 @@
 package me.gamercoder215.mobchip.abstraction.v1_17_R1;
 
+import me.gamercoder215.mobchip.abstraction.ChipUtil;
 import me.gamercoder215.mobchip.abstraction.ChipUtil1_17_R1;
 import me.gamercoder215.mobchip.combat.CombatEntry;
 import me.gamercoder215.mobchip.combat.EntityCombatTracker;
 import net.minecraft.world.damagesource.CombatTracker;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Mob;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -43,9 +43,7 @@ public class EntityCombatTracker1_17_R1 implements EntityCombatTracker {
             f.setAccessible(true);
             ((List<net.minecraft.world.damagesource.CombatEntry>) f.get(handle)).stream().map(en -> ChipUtil1_17_R1.fromNMS(m, en)).forEach(entries::add);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return entries;
     }
@@ -61,9 +59,7 @@ public class EntityCombatTracker1_17_R1 implements EntityCombatTracker {
             Method m = List.class.getMethod("add", Object.class);
             m.invoke(entries, ChipUtil1_17_R1.toNMS(entry));
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 

--- a/1_18_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R1.java
+++ b/1_18_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R1.java
@@ -558,8 +558,7 @@ public final class ChipUtil1_18_R1 implements ChipUtil {
             Behavior<? super net.minecraft.world.entity.LivingEntity> b = (Behavior<? super net.minecraft.world.entity.LivingEntity>) c.newInstance(args);
             return new BehaviorResult1_18_R1(b, nms);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1115,8 +1114,7 @@ public final class ChipUtil1_18_R1 implements ChipUtil {
                 }
             }
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
 
         return null;
@@ -1156,8 +1154,7 @@ public final class ChipUtil1_18_R1 implements ChipUtil {
             }
             return null;
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1169,8 +1166,7 @@ public final class ChipUtil1_18_R1 implements ChipUtil {
 
             return m.invoke(g, args);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1385,9 +1381,7 @@ public final class ChipUtil1_18_R1 implements ChipUtil {
             m.setAccessible(true);
             m.invoke(nmsMob, list.stream().map(ChipUtil1_18_R1::toNMS).collect(Collectors.toList()));
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 

--- a/1_18_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_18_R1/EntityCombatTracker1_18_R1.java
+++ b/1_18_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_18_R1/EntityCombatTracker1_18_R1.java
@@ -1,10 +1,10 @@
 package me.gamercoder215.mobchip.abstraction.v1_18_R1;
 
+import me.gamercoder215.mobchip.abstraction.ChipUtil;
 import me.gamercoder215.mobchip.abstraction.ChipUtil1_18_R1;
 import me.gamercoder215.mobchip.combat.CombatEntry;
 import me.gamercoder215.mobchip.combat.EntityCombatTracker;
 import net.minecraft.world.damagesource.CombatTracker;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Mob;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -43,9 +43,7 @@ public class EntityCombatTracker1_18_R1 implements EntityCombatTracker {
             f.setAccessible(true);
             ((List<net.minecraft.world.damagesource.CombatEntry>) f.get(handle)).stream().map(en -> ChipUtil1_18_R1.fromNMS(m, en)).forEach(entries::add);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return entries;
     }
@@ -61,9 +59,7 @@ public class EntityCombatTracker1_18_R1 implements EntityCombatTracker {
             Method m = List.class.getMethod("add", Object.class);
             m.invoke(entries, ChipUtil1_18_R1.toNMS(entry));
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 

--- a/1_18_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R2.java
+++ b/1_18_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_18_R2.java
@@ -558,8 +558,7 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
             Behavior<? super net.minecraft.world.entity.LivingEntity> b = (Behavior<? super net.minecraft.world.entity.LivingEntity>) c.newInstance(args);
             return new BehaviorResult1_18_R2(b, nms);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1115,8 +1114,7 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
                 }
             }
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
 
         return null;
@@ -1156,8 +1154,7 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
             }
             return null;
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1169,8 +1166,7 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
 
             return m.invoke(g, args);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1326,9 +1322,7 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
             frozen.setAccessible(true);
             frozen.set(registry, isLocked);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 
@@ -1406,9 +1400,7 @@ public final class ChipUtil1_18_R2 implements ChipUtil {
             m.setAccessible(true);
             m.invoke(nmsMob, list.stream().map(ChipUtil1_18_R2::toNMS).collect(Collectors.toList()));
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 

--- a/1_18_R2/src/main/java/me/gamercoder215/mobchip/abstraction/v1_18_R2/EntityCombatTracker1_18_R2.java
+++ b/1_18_R2/src/main/java/me/gamercoder215/mobchip/abstraction/v1_18_R2/EntityCombatTracker1_18_R2.java
@@ -1,10 +1,10 @@
 package me.gamercoder215.mobchip.abstraction.v1_18_R2;
 
+import me.gamercoder215.mobchip.abstraction.ChipUtil;
 import me.gamercoder215.mobchip.abstraction.ChipUtil1_18_R2;
 import me.gamercoder215.mobchip.combat.CombatEntry;
 import me.gamercoder215.mobchip.combat.EntityCombatTracker;
 import net.minecraft.world.damagesource.CombatTracker;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Mob;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -43,9 +43,7 @@ public class EntityCombatTracker1_18_R2 implements EntityCombatTracker {
             f.setAccessible(true);
             ((List<net.minecraft.world.damagesource.CombatEntry>) f.get(handle)).stream().map(en -> ChipUtil1_18_R2.fromNMS(m, en)).forEach(entries::add);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return entries;
     }
@@ -61,9 +59,7 @@ public class EntityCombatTracker1_18_R2 implements EntityCombatTracker {
             Method m = List.class.getMethod("add", Object.class);
             m.invoke(entries, ChipUtil1_18_R2.toNMS(entry));
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 

--- a/1_19_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_19_R1.java
+++ b/1_19_R1/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_19_R1.java
@@ -570,8 +570,7 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
             Behavior<? super net.minecraft.world.entity.LivingEntity> b = (Behavior<? super net.minecraft.world.entity.LivingEntity>) c.newInstance(args);
             return new BehaviorResult1_19_R1(b, nms);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -684,9 +683,7 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
             m.setAccessible(true);
             m.invoke(nmsMob, list.stream().map(ChipUtil1_19_R1::toNMS).collect(Collectors.toList()));
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 
@@ -1145,8 +1142,7 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
                 }
             }
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
 
         return null;
@@ -1186,8 +1182,7 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
             }
             return null;
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1199,8 +1194,7 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
 
             return m.invoke(g, args);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1361,9 +1355,7 @@ public final class ChipUtil1_19_R1 implements ChipUtil {
             frozen.setAccessible(true);
             frozen.set(registry, isLocked);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 

--- a/1_19_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_19_R1/EntityCombatTracker1_19_R1.java
+++ b/1_19_R1/src/main/java/me/gamercoder215/mobchip/abstraction/v1_19_R1/EntityCombatTracker1_19_R1.java
@@ -1,10 +1,10 @@
 package me.gamercoder215.mobchip.abstraction.v1_19_R1;
 
+import me.gamercoder215.mobchip.abstraction.ChipUtil;
 import me.gamercoder215.mobchip.abstraction.ChipUtil1_19_R1;
 import me.gamercoder215.mobchip.combat.CombatEntry;
 import me.gamercoder215.mobchip.combat.EntityCombatTracker;
 import net.minecraft.world.damagesource.CombatTracker;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Mob;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -43,9 +43,7 @@ public class EntityCombatTracker1_19_R1 implements EntityCombatTracker {
             f.setAccessible(true);
             ((List<net.minecraft.world.damagesource.CombatEntry>) f.get(handle)).stream().map(en -> ChipUtil1_19_R1.fromNMS(m, en)).forEach(entries::add);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return entries;
     }
@@ -61,9 +59,7 @@ public class EntityCombatTracker1_19_R1 implements EntityCombatTracker {
             Method m = List.class.getMethod("add", Object.class);
             m.invoke(entries, ChipUtil1_19_R1.toNMS(entry));
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 

--- a/1_19_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_19_R2.java
+++ b/1_19_R2/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil1_19_R2.java
@@ -572,8 +572,7 @@ public final class ChipUtil1_19_R2 implements ChipUtil {
             Behavior<? super net.minecraft.world.entity.LivingEntity> b = (Behavior<? super net.minecraft.world.entity.LivingEntity>) c.newInstance(args);
             return new BehaviorResult1_19_R2(b, nms);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -686,9 +685,7 @@ public final class ChipUtil1_19_R2 implements ChipUtil {
             m.setAccessible(true);
             m.invoke(nmsMob, list.stream().map(ChipUtil1_19_R2::toNMS).collect(Collectors.toList()));
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 
@@ -1153,8 +1150,7 @@ public final class ChipUtil1_19_R2 implements ChipUtil {
                 }
             }
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
 
         return null;
@@ -1194,8 +1190,7 @@ public final class ChipUtil1_19_R2 implements ChipUtil {
             }
             return null;
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1207,8 +1202,7 @@ public final class ChipUtil1_19_R2 implements ChipUtil {
 
             return m.invoke(g, args);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
             return null;
         }
     }
@@ -1373,9 +1367,7 @@ public final class ChipUtil1_19_R2 implements ChipUtil {
             frozen.setAccessible(true);
             frozen.set(registry, isLocked);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 

--- a/1_19_R2/src/main/java/me/gamercoder215/mobchip/abstraction/v1_19_R2/EntityCombatTracker1_19_R2.java
+++ b/1_19_R2/src/main/java/me/gamercoder215/mobchip/abstraction/v1_19_R2/EntityCombatTracker1_19_R2.java
@@ -1,10 +1,10 @@
 package me.gamercoder215.mobchip.abstraction.v1_19_R2;
 
+import me.gamercoder215.mobchip.abstraction.ChipUtil;
 import me.gamercoder215.mobchip.abstraction.ChipUtil1_19_R2;
 import me.gamercoder215.mobchip.combat.CombatEntry;
 import me.gamercoder215.mobchip.combat.EntityCombatTracker;
 import net.minecraft.world.damagesource.CombatTracker;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Mob;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -43,9 +43,7 @@ public class EntityCombatTracker1_19_R2 implements EntityCombatTracker {
             f.setAccessible(true);
             ((List<net.minecraft.world.damagesource.CombatEntry>) f.get(handle)).stream().map(en -> ChipUtil1_19_R2.fromNMS(m, en)).forEach(entries::add);
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
         return entries;
     }
@@ -61,9 +59,7 @@ public class EntityCombatTracker1_19_R2 implements EntityCombatTracker {
             Method m = List.class.getMethod("add", Object.class);
             m.invoke(entries, ChipUtil1_19_R2.toNMS(entry));
         } catch (Exception e) {
-            Bukkit.getLogger().severe(e.getClass().getSimpleName());
-            Bukkit.getLogger().severe(e.getMessage());
-            for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+            ChipUtil.printStackTrace(e);
         }
     }
 

--- a/abstraction/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil.java
+++ b/abstraction/src/main/java/me/gamercoder215/mobchip/abstraction/ChipUtil.java
@@ -147,9 +147,8 @@ public interface ChipUtil {
             for (Map.Entry<Integer, Pathfinder> e : goals.entrySet())
                 addPathfinder(e.getValue(), e.getKey(), target.get(e.getKey()));
         } catch (ClassCastException e) {
-            Bukkit.getLogger().severe("[MobChip] Invalid Projectile Source: " + e.getMessage());
-            for (StackTraceElement s : e.getStackTrace())
-                Bukkit.getLogger().severe("[MobChip] " + s.toString());
+            Bukkit.getLogger().severe("[MobChip] Invalid Projectile Source");
+            printStackTrace(e);
         }
     }
 
@@ -184,4 +183,12 @@ public interface ChipUtil {
         }
     }
 
+    static void printStackTrace(Throwable e) {
+        Bukkit.getLogger().severe(e.getClass().getName() + ": " + e.getMessage());
+        for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe("    " + s.toString());
+        if (e.getCause() != null) {
+            Bukkit.getLogger().severe("Caused by:");
+            printStackTrace(e.getCause());
+        }
+    }
 }

--- a/base/src/main/java/me/gamercoder215/mobchip/ai/memories/EntityMemory.java
+++ b/base/src/main/java/me/gamercoder215/mobchip/ai/memories/EntityMemory.java
@@ -18,7 +18,7 @@ import java.util.Arrays;
  * @param <T> Type of Memory
  */
 public final class EntityMemory<T> implements Memory<T> {
-	
+
 	/**
 	 * Whether this Entity is not admiring another entity.
 	 */
@@ -204,6 +204,7 @@ public final class EntityMemory<T> implements Memory<T> {
      * This entity's Ram Cooldown (Typically for Ravagers).
      */
     public static final EntityMemory<Integer> RAM_COOLDOWN = new EntityMemory<>(Integer.class, "ram_cooldown_ticks");
+    public static final EntityMemory<Boolean> IS_PANICKING = new EntityMemory<>(Boolean.class, "is_panicking");
     /**
      * The Entity that this Entity is angry at.
      */
@@ -305,7 +306,7 @@ public final class EntityMemory<T> implements Memory<T> {
         this.bukkit = bukkit;
         this.key = key;
     }
-    
+
     /**
      * Get the Bukkit Class of this EntityMemory.
      * @return Bukkit Class
@@ -358,5 +359,5 @@ public final class EntityMemory<T> implements Memory<T> {
     }
 
 
-    
+
 }

--- a/base/src/main/java/me/gamercoder215/mobchip/bosses/Boss.java
+++ b/base/src/main/java/me/gamercoder215/mobchip/bosses/Boss.java
@@ -237,8 +237,7 @@ public abstract class Boss<T extends Mob> {
                                 Bukkit.getLogger().severe(e.getCause().getMessage());
                                 for (StackTraceElement s : e.getCause().getStackTrace()) Bukkit.getLogger().severe(s.toString());
                             } catch (Exception e) {
-                                Bukkit.getLogger().severe(e.getClass().getSimpleName());
-                                Bukkit.getLogger().severe(e.getMessage());
+                                                    Bukkit.getLogger().severe(e.getMessage());
                                 for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
                             }
                         }

--- a/bukkit/src/main/java/me/gamercoder215/mobchip/bukkit/BukkitBrain.java
+++ b/bukkit/src/main/java/me/gamercoder215/mobchip/bukkit/BukkitBrain.java
@@ -180,9 +180,7 @@ public class BukkitBrain implements EntityBrain {
 			}
 		} catch (ClassNotFoundException | NoSuchMethodException ignored) {}
 		catch (Exception e) {
-			Bukkit.getLogger().severe(e.getClass().getSimpleName());
-			Bukkit.getLogger().severe(e.getMessage());
-			for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
+			ChipUtil.printStackTrace(e);
 		}
 
 		if (m instanceof Villager) return new BukkitVillagerBehavior((Villager) m);


### PR DESCRIPTION
## Info
This PR makes printed stack traces consistent and improves formatting.

## Details
Previously, stack traces were printed through the Bukkit logger using code like this:
```java
Bukkit.getLogger().severe(e.getMessage());
for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe(s.toString());
```
Sometimes the exception type would be printed, sometimes not (different places in the code did it differently.) It's also not easy to tell when one exception ends and another begins if you're trying to track down more than one. This is the new code:

```java
static void printStackTrace(Throwable e) {
    Bukkit.getLogger().severe(e.getClass().getName() + ": " + e.getMessage());
    for (StackTraceElement s : e.getStackTrace()) Bukkit.getLogger().severe("    " + s.toString());
    if (e.getCause() != null) {
        Bukkit.getLogger().severe("Caused by:");
        printStackTrace(e.getCause());
    }
}
```

## Tested Environments

### OS
OS: Debian 11

### Java / Minecraft

#### MC Builds
- [X] Tested on Latest Spigot Version
- [X] Tested on Latest Paper / Purpur Version

#### JDK Builds
Tested on:
- [X] JDK Version 8/11
- [X] JDK Version 17/18

## Demonstration
New stack traces:

```
[20:59:10] [Server thread/ERROR]: java.lang.ClassNotFoundException: net.minecraft.server.v1_16_R3.AnimalPanic
[20:59:10] [Server thread/ERROR]:     org.bukkit.plugin.java.PluginClassLoader.loadClass0(PluginClassLoader.java:138)
[20:59:10] [Server thread/ERROR]:     org.bukkit.plugin.java.PluginClassLoader.loadClass(PluginClassLoader.java:99)
[20:59:10] [Server thread/ERROR]:     java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:519)
[20:59:10] [Server thread/ERROR]:     java.base/java.lang.Class.forName0(Native Method)
[20:59:10] [Server thread/ERROR]:     java.base/java.lang.Class.forName(Class.java:375)
[20:59:10] [Server thread/ERROR]:     be.isach.ultracosmetics.shaded.mobchip.abstraction.ChipUtil1_16_R3.runBehavior(ChipUtil1_16_R3.java:423)
[20:59:10] [Server thread/ERROR]:     be.isach.ultracosmetics.shaded.mobchip.abstraction.ChipUtil1_16_R3.runBehavior(ChipUtil1_16_R3.java:396)
[20:59:10] [Server thread/ERROR]:     be.isach.ultracosmetics.shaded.mobchip.bukkit.BukkitEntityBehavior.run(BukkitEntityBehavior.java:29)
[20:59:10] [Server thread/ERROR]:     be.isach.ultracosmetics.shaded.mobchip.bukkit.BukkitCreatureBehavior.panic(BukkitCreatureBehavior.java:24)
[20:59:10] [Server thread/ERROR]:     be.isach.ultracosmetics.shaded.mobchip.ai.behavior.CreatureBehavior.panic(CreatureBehavior.java:28)
[20:59:10] [Server thread/ERROR]:     be.isach.ultracosmetics.cosmetics.gadgets.GadgetExplosiveSheep$SheepColorRunnable.lambda$run$0(GadgetExplosiveSheep.java:128)
[20:59:10] [Server thread/ERROR]:     be.isach.ultracosmetics.util.EntitySpawner.run(EntitySpawner.java:65)
[20:59:10] [Server thread/ERROR]:     org.bukkit.craftbukkit.v1_16_R3.scheduler.CraftTask.run(CraftTask.java:81)
[20:59:10] [Server thread/ERROR]:     org.bukkit.craftbukkit.v1_16_R3.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:400)
[20:59:10] [Server thread/ERROR]:     net.minecraft.server.v1_16_R3.MinecraftServer.b(MinecraftServer.java:1179)
[20:59:10] [Server thread/ERROR]:     net.minecraft.server.v1_16_R3.DedicatedServer.b(DedicatedServer.java:394)
[20:59:10] [Server thread/ERROR]:     net.minecraft.server.v1_16_R3.MinecraftServer.a(MinecraftServer.java:1127)
[20:59:10] [Server thread/ERROR]:     net.minecraft.server.v1_16_R3.MinecraftServer.w(MinecraftServer.java:966)
[20:59:10] [Server thread/ERROR]:     net.minecraft.server.v1_16_R3.MinecraftServer.lambda$0(MinecraftServer.java:273)
[20:59:10] [Server thread/ERROR]:     java.base/java.lang.Thread.run(Thread.java:831)
```
