### PR TITLE
Fix some modules not being shaded correctly

### DIFF
--- a/nms/1_18_R1/build.gradle.kts
+++ b/nms/1_18_R1/build.gradle.kts
@@ -26,10 +26,6 @@ tasks {
         dependsOn("remap")
     }
 
-    jar.configure {
-        enabled = false
-    }
-
     remap {
         dependsOn("shadowJar")
 

--- a/nms/1_18_R2/build.gradle.kts
+++ b/nms/1_18_R2/build.gradle.kts
@@ -26,10 +26,6 @@ tasks {
         dependsOn("remap")
     }
 
-    jar.configure {
-        enabled = false
-    }
-
     remap {
         dependsOn("shadowJar")
 

--- a/nms/1_19_R1/build.gradle.kts
+++ b/nms/1_19_R1/build.gradle.kts
@@ -26,10 +26,6 @@ tasks {
         dependsOn("remap")
     }
 
-    jar.configure {
-        enabled = false
-    }
-
     remap {
         dependsOn("shadowJar")
 

--- a/nms/1_19_R2/build.gradle.kts
+++ b/nms/1_19_R2/build.gradle.kts
@@ -26,10 +26,6 @@ tasks {
         dependsOn("remap")
     }
 
-    jar.configure {
-        enabled = false
-    }
-
     remap {
         dependsOn("shadowJar")
 

--- a/nms/1_19_R3/build.gradle.kts
+++ b/nms/1_19_R3/build.gradle.kts
@@ -26,10 +26,6 @@ tasks {
         dependsOn("remap")
     }
 
-    jar.configure {
-        enabled = false
-    }
-
     remap {
         dependsOn("shadowJar")
 

--- a/nms/1_20_R1/build.gradle.kts
+++ b/nms/1_20_R1/build.gradle.kts
@@ -26,10 +26,6 @@ tasks {
         dependsOn("remap")
     }
 
-    jar.configure {
-        enabled = false
-    }
-
     remap {
         dependsOn("shadowJar")
 

--- a/nms/1_20_R2/build.gradle.kts
+++ b/nms/1_20_R2/build.gradle.kts
@@ -26,10 +26,6 @@ tasks {
         dependsOn("remap")
     }
 
-    jar.configure {
-        enabled = false
-    }
-
     remap {
         dependsOn("shadowJar")
 

--- a/nms/1_20_R3/build.gradle.kts
+++ b/nms/1_20_R3/build.gradle.kts
@@ -26,10 +26,6 @@ tasks {
         dependsOn("remap")
     }
 
-    jar.configure {
-        enabled = false
-    }
-
     remap {
         dependsOn("shadowJar")
 

--- a/nms/1_20_R4/build.gradle.kts
+++ b/nms/1_20_R4/build.gradle.kts
@@ -26,10 +26,6 @@ tasks {
         dependsOn("remap")
     }
 
-    jar.configure {
-        enabled = false
-    }
-
     remap {
         dependsOn("shadowJar")
 


### PR DESCRIPTION
## Info
This PR fixes some modules not being shaded correctly into a plugin that uses MobChip as a dependency.

## Details
As mentioned in Discord, when shading MobChip into a plugin, only the modules that don't use Java 17 are included; the modules that use Java 8 or Java 21 are all fine.
![mobchip modules](https://github.com/gmitch215/MobChip/assets/17661376/ff45111e-101b-40bc-ac45-8faf04b14ab0)

Each module that depends on Java 17+ has these three lines in their `build.gradle.kts`:
```kotlin
jar.configure {
    enabled = false
}
```
I'm unsure what these lines do exactly, but removing them seems to have no ill effects (but please verify my results!). Note that while these lines are present in module `v1_20_R4` as well, it uses Java 21 and isn't affected by this issue, so I haven't modified it.

## Tested Environments

### OS
OS: Windows 10

### Java / Minecraft

#### MC Builds
- [ ] Tested on Latest Spigot Version
- [X] Tested on Latest Paper / Purpur Version

#### JDK Builds
Tested on:
- [ ] ~~JDK Version 8/11~~ (not affected by this issue)
- [X] JDK Version 17/18

## Demonstration
Minimum sample `build.gradle` for testing:
```groovy
plugins {
    id 'java-library'
    id 'io.github.goooler.shadow' version '8.1.7'
}

java {
    toolchain {
        languageVersion = JavaLanguageVersion.of(17)
    }
}

repositories {
    maven { url "https://repo.codemc.io/repository/maven-snapshots/" }
}

dependencies {
    implementation 'me.gamercoder215:mobchip-bukkit:1.10.1-SNAPSHOT'
    // Use this line for testing a local jar
    //implementation fileTree(dir: '.', include: ['mobchip-bukkit-1.10.1-SNAPSHOT.jar'])
}
```